### PR TITLE
fix int args being turned into strings

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -30,7 +30,7 @@ def escape_item(val, charset):
         val = val.decode(charset)
     encoder = encoders[type(val)]
     val = encoder(val)
-    if type(val) is str:
+    if type(val) in [str, int]:
         return val
     val = val.encode(charset)
     return val
@@ -59,7 +59,10 @@ def escape_bool(value):
 def escape_object(value):
     return str(value)
 
-escape_int = escape_long = escape_object
+def escape_int(value):
+    return value
+
+escape_long = escape_object
 
 def escape_float(value):
     return ('%.15g' % value)


### PR DESCRIPTION
```
args = {'foo': 1}
query = 'SELECT foo FROM bar WHERE foo=%(foo)s'
cursor.execute(query, args)

TypeError: %d format: a number is required, not str
```

Escaped `int` args get turned into `str` and cause the error, the attached commit fixes this.
