### PR TITLE
Implementation of SSCursor, and dump_packet() Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,3 @@ __pycache__
 py3k
 dist
 PyMySQL.egg-info
-Xcode
-.DS_Store
-tests/test.py

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -43,7 +43,7 @@ from err import raise_mysql_exception, Warning, Error, \
      InterfaceError, DataError, DatabaseError, OperationalError, \
      IntegrityError, InternalError, NotSupportedError, ProgrammingError
 
-DEBUG = True
+DEBUG = False
 
 NULL_COLUMN = 251
 UNSIGNED_CHAR_COLUMN = 251

--- a/pymysql/tests/base.py
+++ b/pymysql/tests/base.py
@@ -5,7 +5,8 @@ class PyMySQLTestCase(unittest.TestCase):
     # Edit this to suit your test environment.
     databases = [
         {"host":"localhost","user":"root",
-         "passwd":"","db":"test_pymysql", "use_unicode": True}]
+         "passwd":"","db":"test_pymysql", "use_unicode": True},
+        {"host":"localhost","user":"root","passwd":"","db":"test_pymysql2"}]
 
     def setUp(self):
         self.connections = []

--- a/pymysql/tests/test_SSCursor.py
+++ b/pymysql/tests/test_SSCursor.py
@@ -10,9 +10,6 @@ except:
     import pymysql.cursors
 
 class TestSSCursor(base.PyMySQLTestCase):
-    #databases = [
-    #    {"host":"localhost","user":"testuser","passwd":"8cp1FEqp","db":"cleure"}]
-
     def test_SSCursor(self):
         affected_rows = 18446744073709551615
     
@@ -75,10 +72,16 @@ class TestSSCursor(base.PyMySQLTestCase):
             self.assertEqual(len(cursor.fetchmany(2)), 2,
                 'fetchmany failed. Number of rows does not match')
             
+            # So MySQLdb won't throw "Commands out of sync"
+            while True:
+                res = cursor.fetchone()
+                if res is None:
+                    break
+            
             # Test update, affected_rows()
             cursor.execute('UPDATE tz_data SET zone = %s', ['Foo'])
             conn.commit()
-            self.assertEqual(conn.affected_rows(), len(data),
+            self.assertEqual(cursor.rowcount, len(data),
                 'Update failed. affected_rows != %s' % (str(len(data))))
             
             # Test executemany


### PR DESCRIPTION
- Implementation of Unbuffered Cursors (SSCursor), for working with very large result sets,
  or for working over slow network connections. Reads rows on-demand instead of
  all-at-once.
- Implementation of OKPacketWrapper, and EOFPacketWrapper classes, which wrap
  around the MysqlPacket class (similar to FieldDescriptorPacket).
- Use try/except:pass in dump_packet() function, to avoid throwing exceptions.

Changes as per discussion:
- Renamed to SSCursor
- Compatible with MySQLdb's implementation
- Unit tests included in pymysql/tests/test_SSCursor.py
