### PR TITLE
Fix _result AttributeError on connect

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -769,7 +769,7 @@ class Connection(object):
 
         # If the last query was unbuffered, make sure it finishes before
         # sending new commands
-        if self._result is not None and self._result.unbuffered_active:
+        if getattr(self, '_result', None) and self._result.unbuffered_active:
             self._result._finish_unbuffered_query()
 
         if isinstance(sql, unicode):


### PR DESCRIPTION
 We may not have a _result yet as it's setup in __init__ _after_ set_charset

This avoids an AttributeError when connecting.

Alternatively we could reorder **init** but the order "smells" deliberate
wrt character encodings so I'm playing it safe.

Signed-off-by: Chris Lamb lamby@debian.org
