### PR TITLE
Bug fixes for Python 3

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -574,14 +574,14 @@ class Connection(object):
 
         self._connect()
 
+        self._result = None
+        self._affected_rows = 0
+        self.host_info = "Not connected"
+
         self.messages = []
         self.set_charset(charset)
         self.encoders = encoders
         self.decoders = conv
-
-        self._result = None
-        self._affected_rows = 0
-        self.host_info = "Not connected"
 
         self.autocommit(False)
 


### PR DESCRIPTION
Working on porting Django to Python 3, I have been using PyMySQL as my adapter to MySQL. I was going to do this just until the MySQLdb project was updated to support Python3, but there seems to be enough support that I am probably going to maintain a mysql_pymysql Django backend, with support for Python 2 and 3.

With that, I have two patches that are needed for PyMySQL to pass all of the Django unit tests under Python 3:

The first patch fixes issue #69 (issue #55 on Google code)

The second patch addresses issue #91

Thanks,
Ian
