### PR TITLE
Fix for Python 2.x mixing unicode and ascii strings

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -92,6 +92,9 @@ class Cursor(object):
 
         # TODO: make sure that conn.escape is correct
 
+        if isinstance(query, unicode):
+            query = query.encode(charset)
+
         if args is not None:
             if isinstance(args, tuple) or isinstance(args, list):
                 escaped_args = tuple(conn.escape(arg) for arg in args)
@@ -103,9 +106,6 @@ class Cursor(object):
                 escaped_args = conn.escape(args)
 
             query = query % escaped_args
-
-        if isinstance(query, unicode):
-            query = query.encode(charset)
 
         result = 0
         try:


### PR DESCRIPTION
The code could fail if a unicode object is used as the query, and a
utf-8 encoded string with characters outside of the ASCII range is
passed in as one of the query arguments. This fix encodes the query in
the appropriate character set _before_ applying the escaped args, as the
MySQLdb adapter does.

This was discovered through the Django unit tests -- specifically, this fixes a failure in httpwrappers.HttpResponseTests.test_iter_content (tests/regressiontests/httpwrappers/tests.py(297))
