### PR TITLE
Fix ping() when connection is not active.

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -694,6 +694,8 @@ class Connection(object):
         ''' Check if the server is alive '''
         try:
             self._execute_command(COM_PING, "")
+            pkt = self.read_packet()
+            return pkt.is_ok_packet()
         except:
             if reconnect:
                 self._connect()
@@ -702,9 +704,6 @@ class Connection(object):
                 exc,value,tb = sys.exc_info()
                 self.errorhandler(None, exc, value)
                 return
-
-        pkt = self.read_packet()
-        return pkt.is_ok_packet()
 
     def set_charset(self, charset):
         try:


### PR DESCRIPTION
With MySQL 5.1.41 the exception happened when doing read_packet()

Here's the traceback without the commit :

```
Traceback (most recent call last):
  File "C:\workspaces\python\py-vb-mysql\test-mysql.py", line 8, in <module>
    conn.ping(True)
  File "c:\workspaces\python\pymysql\pymysql\connections.py", line 641, in ping
    [Finished]pkt = self.read_packet()
  File "c:\workspaces\python\pymysql\pymysql\connections.py", line 685, in read_packet
    packet = packet_type(self)
  File "c:\workspaces\python\pymysql\pymysql\connections.py", line 200, in __init__
    self.__recv_packet()
  File "c:\workspaces\python\pymysql\pymysql\connections.py", line 206, in __recv_packet
    raise OperationalError(2013, "Lost connection to MySQL server during query")
pymysql.err.OperationalError: (2013, 'Lost connection to MySQL server during query')
```
