### PR TITLE
parse port in my.cnf file as integer

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -544,7 +544,7 @@ class Connection(object):
             host = _config("host", host)
             db = _config("db",db)
             unix_socket = _config("socket",unix_socket)
-            port = _config("port", port)
+            port = int(_config("port", port))
             charset = _config("default-character-set", charset)
 
         self.host = host


### PR DESCRIPTION
At present, all elements parsed from my.cnf files are parsed as strings. This results in the following error when such a file specifies a port number:

```
>>> pymysql.connect(read_default_file=os.path.expanduser('~/.my.cnf'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/cduffy/VC/PyMySQL/pymysql/__init__.py", line 93, in Connect
    return Connection(*args, **kwargs)
  File "/home/cduffy/VC/PyMySQL/pymysql/connections.py", line 575, in __init__
    self._connect()
  File "/home/cduffy/VC/PyMySQL/pymysql/connections.py", line 734, in _connect
    sock.connect((self.host, self.port))
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
TypeError: an integer is required
```

The attached diff resolves this issue.
