### PR TITLE
Fix 114 - autocommit is not set after reconnecting with ping()

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -572,18 +572,18 @@ class Connection(object):
         self.cursorclass = cursorclass
         self.connect_timeout = connect_timeout
 
-        self._connect()
-
         self._result = None
         self._affected_rows = 0
         self.host_info = "Not connected"
 
         self.messages = []
+
+        self.autocommit_mode = False
+        self._connect()
+
         self.set_charset(charset)
         self.encoders = encoders
         self.decoders = conv
-
-        self.autocommit(False)
 
         if sql_mode is not None:
             c = self.cursor()
@@ -612,14 +612,18 @@ class Connection(object):
         self.wfile = None
 
     def autocommit(self, value):
+        self.autocommit_mode = value
+        self._send_autocommit_mode()
+
+    def _send_autocommit_mode(self):
         ''' Set whether or not to commit after every execute() '''
         try:
             self._execute_command(COM_QUERY, "SET AUTOCOMMIT = %s" % \
-                                      self.escape(value))
+                                      self.escape(self.autocommit_mode))
             self.read_packet()
         except:
             exc,value,tb = sys.exc_info()
-            self.errorhandler(None, exc, value)
+            self.errorhandler(None, exc, self.autocommit_mode)
 
     def commit(self):
         ''' Commit changes to stable storage '''
@@ -739,6 +743,8 @@ class Connection(object):
             self.wfile = self.socket.makefile("wb")
             self._get_server_information()
             self._request_authentication()
+
+            self._send_autocommit_mode()
         except socket.error, e:
             raise OperationalError(2003, "Can't connect to MySQL server on %r (%s)" % (self.host, e.args[0]))
 

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -283,6 +283,18 @@ class TestGitHubIssues(base.PyMySQLTestCase):
         self.assertFalse(c.fetchone()[0])
         conn.close()
 
+        # Ensure autocommit() is still working
+        conn = pymysql.connect(host="localhost", user="root", db=self.databases[0]["db"], charset="utf8")
+        c = conn.cursor()
+        c.execute("""select @@autocommit;""")
+        self.assertFalse(c.fetchone()[0])
+        conn.close()
+        conn.ping()
+        conn.autocommit(True)
+        c.execute("""select @@autocommit;""")
+        self.assertTrue(c.fetchone()[0])
+        conn.close()
+
 __all__ = ["TestOldIssues", "TestNewIssues", "TestGitHubIssues"]
 
 if __name__ == "__main__":


### PR DESCRIPTION
The autocommit was not set after reconnecting with ping().

I think pymysql should also send 'set charset', 'sql_mode' and the 'init_command' when reconnecting with ping().
