### PR TITLE
OrderedDictCursor

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -294,6 +294,39 @@ class DictCursor(Cursor):
             result = [ dict(zip(self._fields, r)) for r in self._rows ]
         self.rownumber = len(self._rows)
         return tuple(result)
+try:
+    from collections import OrderedDict
+except ImportError:
+    try:
+        from OrderedDict import OrderedDict
+    except ImportError:
+        OrderedDict = None
+
+if OrderedDict:
+    class OrderedDictCursor(DictCursor):
+        """A cursor which returns results as an ordered dictionary."""
+        def dict_to_ordered_dict(self, d):
+            """
+            d is the dict to convert
+            f is a list of fields, in order
+            """
+            return OrderedDict(zip(self._fields, (d[f] for f in self._fields))) if d else None
+    
+        def fetchone(self):
+            """Fetch the next row"""
+            result = super(OrderedDictCursor, self).fetchone()
+            result = self.dict_to_ordered_dict(result)
+            return result
+    
+        def fetchmany(self, size=None):
+            """Fetch several rows"""
+            result = super(OrderedDictCursor, self).fetchmany(size)
+            return tuple(self.dict_to_ordered_dict(r) for r in result)
+    
+        def fetchall(self):
+            """Fetch all the rows"""
+            result = super(OrderedDictCursor, self).fetchall()
+            return tuple(self.dict_to_ordered_dict(r) for r in result)
 
 class SSCursor(Cursor):
     """

--- a/pymysql/tests/test_OrderedDictCursor.py
+++ b/pymysql/tests/test_OrderedDictCursor.py
@@ -46,6 +46,24 @@ class TestOrderedDictCursor(base.PyMySQLTestCase):
             c.execute("SELECT * from ordereddictcursor")
             r = c.fetchmany(2)
             self.assertEqual((bob,jim), r, "fetchmany failed via OrderedDictCursor")
+            # make sure fields are indeed ordered for a single item
+            c.execute("SELECT * from ordereddictcursor")
+            r = c.fetchone()
+            fields = [f for f in r]
+            self.assertEqual(fields, ['name', 'age', 'DOB'])
+            # make sure fields are indeed ordered for several items
+            c.execute("SELECT * from ordereddictcursor")
+            r = c.fetchmany(2)
+            for rec in r:
+                fields = [f for f in rec]
+                self.assertEqual(fields, ['name', 'age', 'DOB'])
+            # make sure fields are indeed ordered for all items
+            c.execute("SELECT * from ordereddictcursor")
+            r = c.fetchall()
+            for rec in r:
+                fields = [f for f in rec]
+                self.assertEqual(fields, ['name', 'age', 'DOB'])
+
         finally:
             c.execute("drop table ordereddictcursor")
 


### PR DESCRIPTION
Thanks for making this package, I have really found it helpful.

Here's a basic implementation of a cursor that returns an ordered dictionary matching the field names of the query, in order.

I have a test for it, which passes.

I wasn't sure what to do for py3k support, nor the best way to disable the functionality if the OrderedDict package (either from collections, for python >= 2.7, or in the OrderedDict.py equivalent recipe for python >= 2.4).

If you elect to include it, please let me know, I'd like to see how to handle both of those things in the future.
