### PR TITLE
Fix README -> README.rst

### DIFF
--- a/build-py3k.sh
+++ b/build-py3k.sh
@@ -7,7 +7,7 @@ cp -rf pymysql py3k/
 cp setup.py py3k/
 cp setup.py.py3k.patch py3k/
 cp CHANGELOG py3k/
-cp README py3k/
+cp README.rst py3k/
 cp LICENSE py3k/
 cd py3k
 2to3 .|patch -p0


### PR DESCRIPTION
The READ.rst name change wasn't reflected in the py3k build script.  It's a minor bug, but might as well fix it.
