### PR TITLE
Make Connect show through help from inner class

### DIFF
--- a/pymysql/__init__.py
+++ b/pymysql/__init__.py
@@ -91,6 +91,11 @@ def Connect(*args, **kwargs):
     """
     from connections import Connection
     return Connection(*args, **kwargs)
+    
+import connections.Connection as _orig_conn
+Connect.__doc__ = _orig_conn.Connection.__init__.__doc__ + """\nSee connections.Connection.__init__() for
+    information about defaults""".
+del _orig_conn
 
 def get_client_info():  # for MySQLdb compatibility
   return '%s.%s.%s' % VERSION


### PR DESCRIPTION
The redirection seems a faff when wanting to quickly look things up while working with pymysql. Grabbing the doco from the inner class (which should always be correct given it is a passthrough) should give a nice link. 

I've removed the "_orig_conn" from the local namespace (del never deletes anything, it just removes that name/ref for it). This keeps it from fouling up the dir(..) output.
