### PR TITLE
Fix __init__.py syntax error and importing under Python 2.7

### DIFF
--- a/pymysql/__init__.py
+++ b/pymysql/__init__.py
@@ -92,7 +92,7 @@ def Connect(*args, **kwargs):
     from connections import Connection
     return Connection(*args, **kwargs)
     
-import pymysql.connections.Connection as _orig_conn
+from pymysql import connections as _orig_conn
 Connect.__doc__ = _orig_conn.Connection.__init__.__doc__ + """\nSee connections.Connection.__init__() for
     information about defaults."""
 del _orig_conn


### PR DESCRIPTION
Commit 050d0df65ba35521b98e353961d0cfbf77a482fb introduced a syntax error:

```
Running setup.py egg_info for package PyMySQL
  Traceback (most recent call last):
    File "<string>", line 16, in <module>
    File "/Volumes/Shared/Users/testing/VirtualEnvs/nti.dataserver/src/pymysql/setup.py", line 25, in <module>
      version_tuple = __import__('pymysql').VERSION
    File "pymysql/__init__.py", line 97
      information about defaults""".
                                   ^
  SyntaxError: invalid syntax
```

This fixes that error by moving the closing period inside the string. It also introduced a bad import:

```
Traceback (most recent call last):
  File "./setup.py", line 25, in <module>
    version_tuple = __import__('pymysql').VERSION
  File "/Users/jmadden/tmp/PyMySQL/pymysql/__init__.py", line 95, in <module>
    import connections.Connection as _orig_conn
ImportError: No module named Connection
```

This replaces `import connections.Connection as _orig_conn` with `from pymysql import connections as _orig_conn` to correct the ImportError
