### PR TITLE
set SO_KEEPALIVE on all connections

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -740,7 +740,7 @@ class Connection(object):
                 sock.settimeout(t)
                 self.host_info = "socket %s:%d" % (self.host, self.port)
                 if DEBUG: print 'connected using socket'
-            sock.setsockopt(socket.IPPROTO_TCP, socket.SO_KEEPALIVE, 1)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
             if self.no_delay:
                 sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.socket = sock


### PR DESCRIPTION
The MySQL client libraries do this automatically, so it makes sense to
do so here, as well.

This fixes #139.
