### PR TITLE
Escape query in cursor.execute

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -92,6 +92,9 @@ class Cursor(object):
 
         # TODO: make sure that conn.escape is correct
 
+        if isinstance(query, bytes):
+            query = query.decode()
+
         if isinstance(query, unicode):
             query = query.encode(charset)
 


### PR DESCRIPTION
In python3, from certain libaries (i.e sqlalchemy),
cursor.execute must deal with query in bytes.

So decode the query, before escape the args.
