### PR TITLE
Remove unjustified uses of bare 'except' clause

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -537,7 +537,7 @@ class Connection(object):
             def _config(key, default):
                 try:
                     return cfg.get(read_default_group,key)
-                except:
+                except Exception:
                     return default
 
             user = _config("user",user)
@@ -623,7 +623,7 @@ class Connection(object):
             self._execute_command(COM_QUERY, "SET AUTOCOMMIT = %s" % \
                                       self.escape(self.autocommit_mode))
             self.read_packet()
-        except:
+        except Exception:
             exc,value,tb = sys.exc_info()
             self.errorhandler(None, exc, self.autocommit_mode)
 
@@ -632,7 +632,7 @@ class Connection(object):
         try:
             self._execute_command(COM_QUERY, "COMMIT")
             self.read_packet()
-        except:
+        except Exception:
             exc,value,tb = sys.exc_info()
             self.errorhandler(None, exc, value)
 
@@ -641,7 +641,7 @@ class Connection(object):
         try:
             self._execute_command(COM_QUERY, "ROLLBACK")
             self.read_packet()
-        except:
+        except Exception:
             exc,value,tb = sys.exc_info()
             self.errorhandler(None, exc, value)
 
@@ -689,7 +689,7 @@ class Connection(object):
         arg = struct.pack('<I', thread_id)
         try:
             self._execute_command(COM_PROCESS_KILL, arg)
-        except:
+        except Exception:
             exc,value,tb = sys.exc_info()
             self.errorhandler(None, exc, value)
             return
@@ -702,7 +702,7 @@ class Connection(object):
             self._execute_command(COM_PING, "")
             pkt = self.read_packet()
             return pkt.is_ok_packet()
-        except:
+        except Exception:
             if reconnect:
                 self._connect()
                 return self.ping(False)
@@ -718,7 +718,7 @@ class Connection(object):
                                       self.escape(charset))
                 self.read_packet()
                 self.charset = charset
-        except:
+        except Exception:
             exc,value,tb = sys.exc_info()
             self.errorhandler(None, exc, value)
 

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -49,7 +49,7 @@ class Cursor(object):
         try:
             while self.nextset():
                 pass
-        except:
+        except Exception:
             pass
 
         self.connection = None
@@ -110,7 +110,7 @@ class Cursor(object):
         result = 0
         try:
             result = self._query(query)
-        except:
+        except Exception:
             exc, value, tb = exc_info()
             del tb
             self.messages.append((exc,value))
@@ -318,7 +318,7 @@ class SSCursor(Cursor):
         try:
             if self._has_next:
                 while self.nextset(): pass
-        except: pass
+        except Exception: pass
 
     def _query(self, q):
         conn = self._get_db()

--- a/pymysql/tests/test_SSCursor.py
+++ b/pymysql/tests/test_SSCursor.py
@@ -3,7 +3,7 @@ import sys
 try:
     from pymysql.tests import base
     import pymysql.cursors
-except:
+except Exception:
     # For local testing from top-level directory, without installing
     sys.path.append('../pymysql')
     from pymysql.tests import base

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -173,7 +173,7 @@ class TestNewIssues(base.PyMySQLTestCase):
             self.fail()
         except pymysql.OperationalError, e:
             self.assertEqual(2003, e.args[0])
-        except:
+        except Exception:
             self.fail()
 
     def test_issue_33(self):
@@ -214,7 +214,7 @@ class TestNewIssues(base.PyMySQLTestCase):
         try:
             c.execute("show tables")
             self.fail()
-        except:
+        except Exception:
             pass
         # check the process list from the other connection
         try:

--- a/pymysql/tests/thirdparty/test_MySQLdb/capabilities.py
+++ b/pymysql/tests/thirdparty/test_MySQLdb/capabilities.py
@@ -44,7 +44,7 @@ class DatabaseTest(unittest.TestCase):
     def table_exists(self, name):
         try:
             self.cursor.execute('select * from %s where 1=0' % name)
-        except:
+        except Exception:
             return False
         else:
             return True


### PR DESCRIPTION
PyMySQL contains several uses of a bare 'except' clause, like this::

```
try:
    do_something()
except:
    handle_error()
```

Using bare except is almost always a bad idea, as it captures whole-program control flow exceptions like SystemExit, KeyboardInterrupt and gevent.Timeout.  This PR changes it to use the "except Exception" form, which should capture anything of interest while leaving control flow exceptions untouched.

As concrete motivation, I found this because the existing code doesn't cooperate with gevent timeouts.  Code like this::

```
with gevent.Timeout(5):
    cursor.execute("SOME LONG RUNNING SQL STATEMENT")
```

Doesn't time out correctly, because PyMySQL swallows the gevent.Timeout exception and converts it into a DBAPI error.  Ideally it would pass through the gevent.Timeout exception unchanged.
