### PR TITLE
Parse full 4-byte unsigned int for server_thread_id.

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -901,7 +901,7 @@ class Connection(object):
         self.server_version = data[i:server_end].decode(self.charset)
 
         i = server_end + 1
-        self.server_thread_id = struct.unpack('<h', data[i:i+2])
+        self.server_thread_id = struct.unpack('<I', data[i:i+4])
 
         i += 4
         self.salt = data[i:i+8]


### PR DESCRIPTION
The connection handshake should parse server_thread_id as a 4-byte unsigned int, not a two-byte signed short.  This matches the format in which threadids are encoded in the kill() method.
