### PR TITLE
correctly update read stream during ssl authentication

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -917,6 +917,7 @@ class Connection(object):
                                           ssl_version=ssl.PROTOCOL_TLSv1,
                                           cert_reqs=ssl.CERT_REQUIRED,
                                           ca_certs=self.ca)
+            self._rfile = _makefile(self.socket, 'rb')
 
         data = data_init + self.user + b'\0' + \
             _scramble(self.password.encode(self.encoding), self.salt)


### PR DESCRIPTION
Previously, secure database connections broke during authentication because when the socket was wrapped using ssl, the read stream remained pointed at the raw socket. This change updates the read stream to point to the secure socket as soon as the secure connection is established.
