### PR TITLE
socket library, import proper errnos

### DIFF
--- a/pymysql/_socketio.py
+++ b/pymysql/_socketio.py
@@ -6,9 +6,12 @@ Copyright (c) 2001-2013 Python Software Foundation; All Rights Reserved.
 
 from socket import *
 import io
+import errno
 
 __all__ = ['SocketIO']
 
+EINTR = errno.EINTR
+_blocking_errnos = { errno.EAGAIN, errno.EWOULDBLOCK }
 
 class SocketIO(io.RawIOBase):
 


### PR DESCRIPTION
If the socket to the mysql server is closed on the other end, an improper error message is raised due to a missing errno constants. 

To duplicate the issue, set the wait_timeout of a mysql server to 60 seconds (the mysql default is 28800) and restart the server. Then create a test script that uses pymysql to establish a connection, sleeps for 70 seconds, then tries to do a select. 

The error that results is as follows:

```
Exception: global name 'EINTR' is not defined
```

which is a red herring. If EINTR is defined, the following error then is produced:

```
Exception: type object '_socketobject' has no attribute '_blocking_errnos'
```

This code appears to be copied from the socket library in the python std lib. pymysql._socket.py needs to have these things defined for the proper error message to display, which should be as follows:

```
Exception: [Errno 54] Connection reset by peer
```

This is the correct error message which a client to use to determine whether it needs to reestablish a connection.
