### PR TITLE
Ensure client password defaults to empty string

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -590,7 +590,7 @@ class Connection(object):
         self.host = host
         self.port = port
         self.user = user or DEFAULT_USER
-        self.password = passwd
+        self.password = passwd or ""
         self.db = database
         self.no_delay = no_delay
         self.unix_socket = unix_socket


### PR DESCRIPTION
In case the a None value is passed during initialization, this ensures the password defaults to an empty string. This prevents receiving a "'NoneType' object has no attribute 'encode'" when preparing the connection.
