### PR TITLE
Avoid exploding when PYTHONOPTIMIZE=2

### DIFF
--- a/pymysql/__init__.py
+++ b/pymysql/__init__.py
@@ -88,8 +88,10 @@ def Connect(*args, **kwargs):
     return Connection(*args, **kwargs)
 
 from pymysql import connections as _orig_conn
-Connect.__doc__ = _orig_conn.Connection.__init__.__doc__ + """\nSee connections.Connection.__init__() for
-    information about defaults."""
+if _orig_conn.Connection.__init__.__doc__ is not None:
+    Connect.__doc__ = _orig_conn.Connection.__init__.__doc__ + ("""
+See connections.Connection.__init__() for information about defaults.
+""")
 del _orig_conn
 
 def get_client_info():  # for MySQLdb compatibility


### PR DESCRIPTION
This changes `pymysql/__init__.py` so that it only tries to set `Connect.__doc__` if `pymysql.connections.Connection.__init__.__doc__` is set to anything.

When PYTHONOPTIMIZE=2, `__doc__` is set to `None` instead of the docstring and the code currently raises a `TypeError`, preventing pymysql from being imported.

pymysql itself may not benefit from `PYTHONOPTIMIZE=2` but this behavior prevents pymysql from being used in any other project that wants to use `PYTHONOPTIMIZE=2`.
