### PR TITLE
change charset to lowercase

### DIFF
--- a/pymysql/charset.py
+++ b/pymysql/charset.py
@@ -34,6 +34,7 @@ class Charsets:
         return self._by_id[id]
 
     def by_name(self, name):
+        name = name.lower()
         for c in self._by_id.values():
             if c.name == name and c.is_default:
                 return c


### PR DESCRIPTION
I found a bug.
in MySQLdb below code is OK.

``` python
   g_db=pymysql.connect(user=env["user"],
                         passwd=env["passwd"],
                         db=env["db"],
                         host=env["host"],
                         use_unicode=True,
                         charset='UTF8')
```

but in PyMySQL, it causes error because it has "utf8" as lowcases
