### PR TITLE
handle dates before 1900

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -89,10 +89,10 @@ def escape_time(obj):
     return escape_str(s)
 
 def escape_datetime(obj):
-    return escape_str(obj.strftime("%Y-%m-%d %H:%M:%S"))
+    return escape_str(obj.isoformat(' '))
 
 def escape_date(obj):
-    return escape_str(obj.strftime("%Y-%m-%d"))
+    return escape_str(obj.isoformat())
 
 def escape_struct_time(obj):
     return escape_datetime(datetime.datetime(*obj[:6]))


### PR DESCRIPTION
this fixes an error in the django test suite:

ValueError: year=1 is before 1900; the datetime strftime() methods require year >= 1900
