### PR TITLE
Removing timezone to enable escaping

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -89,9 +89,11 @@ def escape_time(obj):
     return escape_str(s)
 
 def escape_datetime(obj):
+    obj = obj.replace(tzinfo=None)
     return escape_str(obj.isoformat(' '))
 
 def escape_date(obj):
+    obj = obj.replace(tzinfo=None)
     return escape_str(obj.isoformat())
 
 def escape_struct_time(obj):


### PR DESCRIPTION
Hi All-
There is an issue here related to #219 where PyMySQL should strip the timezone from the datetime before inserting. Right now it is failing on the insert, since mysql doesn't take timezone info.

Thanks!