### PR TITLE
Allow for mysql negative values with 0 hour timedelta

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -152,12 +152,16 @@ def convert_timedelta(obj):
             (obj, tail) = obj.split('.')
             microseconds = float('0.' + tail) * 1e6
         hours, minutes, seconds = obj.split(':')
+        negate = 1
+        if hours.startswith("-"):
+            hours = hours[1:]
+            negate = -1
         tdelta = datetime.timedelta(
             hours = int(hours),
             minutes = int(minutes),
             seconds = int(seconds),
             microseconds = int(microseconds)
-            )
+            ) * negate
         return tdelta
     except ValueError:
         return None

--- a/pymysql/tests/test_basic.py
+++ b/pymysql/tests/test_basic.py
@@ -112,10 +112,14 @@ class TestConversion(base.PyMySQLTestCase):
         """ test timedelta conversion """
         conn = self.connections[0]
         c = conn.cursor()
-        c.execute("select time('12:30'), time('23:12:59'), time('23:12:59.05100')")
+        c.execute("select time('12:30'), time('23:12:59'), time('23:12:59.05100'), time('-12:30'), time('-23:12:59'), time('-23:12:59.05100'), time('-00:30')")
         self.assertEqual((datetime.timedelta(0, 45000),
                           datetime.timedelta(0, 83579),
-                          datetime.timedelta(0, 83579, 51000)),
+                          datetime.timedelta(0, 83579, 51000),
+                          -datetime.timedelta(0, 45000),
+                          -datetime.timedelta(0, 83579),
+                          -datetime.timedelta(0, 83579, 51000),
+                          -datetime.timedelta(0, 1800)),
                          c.fetchone())
 
     def test_datetime(self):


### PR DESCRIPTION
mysql times with leading zeros for hours result in positive timedeltas.

for example

``` python
convert_timedelta("-00:30") == convert_timedelta("00:30")
```
