### PR TITLE
Fix set literal to set() for Py2.6 compile error

### DIFF
--- a/pymysql/_socketio.py
+++ b/pymysql/_socketio.py
@@ -11,7 +11,7 @@ import errno
 __all__ = ['SocketIO']
 
 EINTR = errno.EINTR
-_blocking_errnos = set((errno.EAGAIN, errno.EWOULDBLOCK))
+_blocking_errnos = (errno.EAGAIN, errno.EWOULDBLOCK)
 
 class SocketIO(io.RawIOBase):
 


### PR DESCRIPTION
In python 2.6, this is a compile error because there are no set literals. :( sadness.
