### PR TITLE
Fixing up tests for Python 3.2

### DIFF
--- a/pymysql/tests/test_basic.py
+++ b/pymysql/tests/test_basic.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import pymysql.cursors
 
 from pymysql.tests import base
@@ -18,7 +20,7 @@ class TestConversion(base.PyMySQLTestCase):
         c.execute("create table test_datatypes (b bit, i int, l bigint, f real, s varchar(32), u varchar(32), bb blob, d date, dt datetime, ts timestamp, td time, t time, st datetime)")
         try:
             # insert values
-            v = (True, -3, 123456789012, 5.7, "hello'\" world", u"Espa\xc3\xb1ol", "binary\x00data".encode(conn.charset), datetime.date(1988,2,2), datetime.datetime.now(), datetime.timedelta(5,6), datetime.time(16,32), time.localtime())
+            v = (True, -3, 123456789012, 5.7, "hello'\" world", "Espa\xc3\xb1ol", "binary\x00data".encode(conn.charset), datetime.date(1988,2,2), datetime.datetime.now(), datetime.timedelta(5,6), datetime.time(16,32), time.localtime())
             c.execute("insert into test_datatypes (b,i,l,f,s,u,bb,d,dt,td,t,st) values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)", v)
             c.execute("select b,i,l,f,s,u,bb,d,dt,td,t,st from test_datatypes")
             r = c.fetchone()
@@ -104,9 +106,9 @@ class TestConversion(base.PyMySQLTestCase):
         conn = self.connections[0]
         c = conn.cursor()
         c.execute("select null,''")
-        self.assertEqual((None,u''), c.fetchone())
+        self.assertEqual((None,''), c.fetchone())
         c.execute("select '',null")
-        self.assertEqual((u'',None), c.fetchone())
+        self.assertEqual(('',None), c.fetchone())
 
     def test_timedelta(self):
         """ test timedelta conversion """

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import pymysql
 from pymysql.tests import base
 try:
@@ -12,6 +14,7 @@ except AttributeError:
     pass
 
 import datetime
+
 
 
 class TestOldIssues(base.PyMySQLTestCase):
@@ -110,9 +113,9 @@ KEY (`station`,`dh`,`echeance`)) ENGINE=MyISAM DEFAULT CHARSET=latin1;""")
         c.execute("drop table if exists issue15")
         c.execute("create table issue15 (t varchar(32))")
         try:
-            c.execute("insert into issue15 (t) values (%s)", (u'\xe4\xf6\xfc',))
+            c.execute("insert into issue15 (t) values (%s)", ('\xe4\xf6\xfc',))
             c.execute("select t from issue15")
-            self.assertEqual(u'\xe4\xf6\xfc', c.fetchone()[0])
+            self.assertEqual('\xe4\xf6\xfc', c.fetchone()[0])
         finally:
             c.execute("drop table issue15")
 


### PR DESCRIPTION
Changing from u"" syntax to using from **future** import unicode_literals

This appears to resolve the test suite issues for 3.2 and the tests now pass ok

  (pymysql)kev@officedev:~/git/PyMySQL$ python3.2 ./runtests.py
  ................Set max_allowed_packet to bigger than 17MB
  ...........................s...x......s.........................................................x.......

---

  Ran 120 tests in 4.152s

  OK (skipped=2, expected failures=2)
  No garbages!

Versions are as follows

  (pymysql)kev@officedev:~/git/PyMySQL$ mysql --version
  mysql  Ver 14.14 Distrib 5.5.35, for debian-linux-gnu (x86_64) using readline 6.2
  (pymysql)kev@officedev:~/git/PyMySQL$ python --version
  Python 3.2.3
