### PR TITLE
Protocol parsing optimizations

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -254,13 +254,19 @@ def convert_mysql_timestamp(timestamp):
 def convert_set(s):
     return set(s.split(","))
 
-def convert_bit(b):
-    #b = "\x00" * (8 - len(b)) + b # pad w/ zeroes
-    #return struct.unpack(">Q", b)[0]
-    #
-    # the snippet above is right, but MySQLdb doesn't process bits,
-    # so we shouldn't either
-    return b
+
+def through(x):
+    return x
+
+
+#def convert_bit(b):
+#    b = "\x00" * (8 - len(b)) + b # pad w/ zeroes
+#    return struct.unpack(">Q", b)[0]
+#    
+#     the snippet above is right, but MySQLdb doesn't process bits,
+#     so we shouldn't either
+convert_bit = through
+
 
 def convert_characters(connection, field, data):
     field_charset = charset_by_id(field.charsetnr).name
@@ -296,10 +302,6 @@ encoders = {
     time.struct_time: escape_struct_time,
     Decimal: str,
 }
-
-
-def through(x):
-    return x
 
 if not PY2 or JYTHON or IRONPYTHON:
     encoders[bytes] = escape_bytes


### PR DESCRIPTION
I've based this on benchmark from Mike Bayer's mini-benchmark from his [evaluation of PyMySQL] (https://wiki.openstack.org/wiki/PyMySQL_evaluation). It showed that the most time-consuming parts of protocol parsing code are:
* converting rows from protocol representation to Python objects;
* lots of `read()` calls;
* huge amount of method calls overall.
This branch summarizes fixes that optimize all of these aspects. Generally speedup is gained by:
* moving work that can be done before row parsing loop to the top of it;
* avoiding copying buffers around (almost all but most general read() calls are eliminated, bytes object concatenation is avoided);
* reducing amount of calls to `struct.unpack` methods my squashing consecutive calls into one (and replacing them with `struct.unpack_from` to avoid extra data copying).

On my machine this branch showed around 25% speed gain in Mike's benchmark.