### PR TITLE
fix issue 288: executemany now works with "insert ... on duplicate update" 

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -147,7 +147,7 @@ class Cursor(object):
         if m:
             q_prefix = m.group(1)
             q_values = m.group(2).rstrip()
-            q_postfix = m.group(3) or ''
+            q_postfix = bytearray(m.group(3) or '')
             assert q_values[0] == '(' and q_values[-1] == ')'
             return self._do_execute_many(q_prefix, q_values, q_postfix, args,
                                          self.max_stmt_length,

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -147,7 +147,7 @@ class Cursor(object):
         if m:
             q_prefix = m.group(1)
             q_values = m.group(2).rstrip()
-            q_postfix = bytearray(m.group(3) or '')
+            q_postfix = m.group(3) or ''
             assert q_values[0] == '(' and q_values[-1] == ')'
             return self._do_execute_many(q_prefix, q_values, q_postfix, args,
                                          self.max_stmt_length,
@@ -161,6 +161,8 @@ class Cursor(object):
         escape = self._escape_args
         if isinstance(prefix, text_type):
             prefix = prefix.encode(encoding)
+        if isinstance(postfix, text_type):
+            postfix = postfix.encode(encoding)
         sql = bytearray(prefix)
         args = iter(args)
         v = values % escape(next(args), conn)

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -11,7 +11,7 @@ from . import err
 #: Regular expression for :meth:`Cursor.executemany`.
 #: executemany only suports simple bulk insert.
 #: You can use it to load large dataset.
-RE_INSERT_VALUES = re.compile(r"""INSERT\s.+\sVALUES\s+(\(\s*%s\s*(,\s*%s\s*)*\))\s*\Z""",
+RE_INSERT_VALUES = re.compile(r"""(INSERT\s.+\sVALUES\s+)(\(\s*%s\s*(?:,\s*%s\s*)*\))(\s*(?:ON DUPLICATE.*)?)\Z""",
                               re.IGNORECASE | re.DOTALL)
 
 
@@ -145,17 +145,18 @@ class Cursor(object):
 
         m = RE_INSERT_VALUES.match(query)
         if m:
-            q_values = m.group(1).rstrip()
+            q_prefix = m.group(1)
+            q_values = m.group(2).rstrip()
+            q_postfix = m.group(3) or ''
             assert q_values[0] == '(' and q_values[-1] == ')'
-            q_prefix = query[:m.start(1)]
-            return self._do_execute_many(q_prefix, q_values, args,
+            return self._do_execute_many(q_prefix, q_values, q_postfix, args,
                                          self.max_stmt_length,
                                          self._get_db().encoding)
 
         self.rowcount = sum(self.execute(query, arg) for arg in args)
         return self.rowcount
 
-    def _do_execute_many(self, prefix, values, args, max_stmt_length, encoding):
+    def _do_execute_many(self, prefix, values, postfix, args, max_stmt_length, encoding):
         conn = self._get_db()
         escape = self._escape_args
         if isinstance(prefix, text_type):
@@ -171,13 +172,13 @@ class Cursor(object):
             v = values % escape(arg, conn)
             if isinstance(v, text_type):
                 v = v.encode(encoding)
-            if len(sql) + len(v) + 1 > max_stmt_length:
-                rows += self.execute(sql)
+            if len(sql) + len(v) + len(postfix) + 1 > max_stmt_length:
+                rows += self.execute(sql + postfix)
                 sql = bytearray(prefix)
             else:
                 sql += b','
             sql += v
-        rows += self.execute(sql)
+        rows += self.execute(sql + postfix)
         self.rowcount = rows
         return rows
 


### PR DESCRIPTION
Instead of falling back to executing each statement separately when "on duplicate update" is there, it builds a batch call.