### PR TITLE
Multi-statement init_command causes subsequent query to fail

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -844,6 +844,9 @@ class Connection(object):
             if self.init_command is not None:
                 c = self.cursor()
                 c.execute(self.init_command)
+                # Wind pass any additional results
+                while self._result.has_next:
+                    self.next_result()
                 self.commit()
 
             if self.autocommit_mode is not None:

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -844,9 +844,7 @@ class Connection(object):
             if self.init_command is not None:
                 c = self.cursor()
                 c.execute(self.init_command)
-                # Wind pass any additional results
-                while self._result.has_next:
-                    self.next_result()
+                c.close()
                 self.commit()
 
             if self.autocommit_mode is not None:

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -69,3 +69,13 @@ class TestConnection(base.PyMySQLTestCase):
         # error occures while reading, not writing because of socket buffer.
         #self.assertEquals(cm.exception.args[0], 2006)
         self.assertIn(cm.exception.args[0], (2006, 2013))
+
+    def test_init_command(self):
+        conn = pymysql.connect(
+            init_command='SELECT "bar"; SELECT "baz"',
+            **self.databases[0]
+        )
+        c = conn.cursor()
+        c.execute('select "foobar";')
+        self.assertEqual(('foobar',), c.fetchone())
+        conn.close()


### PR DESCRIPTION
Given that the CLIENT.MULTI_STATEMENTS flag is set, it is valid for the init_command supplied by the connection contain multiple statements.  Since on one ok_packet is read this causes subsequent queries to return unexpected results since client/server are out of sync.

Demonstrated by:
```
    def test_init_command(self):
        conn = pymysql.connect(
            init_command='SELECT "baz"; SELECT "boz"',
            **self.databases[0]
        )
        c = conn.cursor()
        c.execute('select "foobar";')
        self.assertEqual(('foobar',), c.fetchone())
        conn.close()
```