### PR TITLE
[for comment] Performance improvements and reduction of client<->server roundtrips

### DIFF
--- a/pymysql/_connection_protocol.py
+++ b/pymysql/_connection_protocol.py
@@ -1,0 +1,73 @@
+# Python implementation of the MySQL client-server protocol
+# http://dev.mysql.com/doc/internals/en/client-server-protocol.html
+
+import collections as _collections
+import struct as _struct
+
+
+def _parse_proto_desc(desc, clsName):
+    struct_types, fields = zip(*desc)
+    expr = "<" + "".join(struct_types)
+    non_empty_fields = (field for field in fields if field is not None)
+    proto_fields = " ".join(non_empty_fields)
+
+    newType = _collections.namedtuple(clsName, proto_fields)
+
+    return expr, newType
+
+
+def _expand_expression(expr, buffer):
+    while True:
+        pos = expr.find('z')
+        if pos < 0:
+            break
+        asciiz_start = _struct.calcsize(expr[:pos])
+        asciiz_len = buffer[asciiz_start:].find('\0')
+        expr = '%s%dsx%s' % (expr[:pos], asciiz_len, expr[pos+1:])
+    return expr
+
+
+def _parse(definition, ret_type, data):
+    parsed_fields = _struct.unpack_from(definition, data)
+    return (ret_type)(*parsed_fields)
+
+
+CLIENT_SECURE_CONNECTION = 0x00008000    # CLIENT.SECURE_CONNECTION
+CLIENT_PLUGIN_AUTH       = 0x00080000    # CLIENT.PLUGIN_AUTH
+
+
+# Define basic protocol
+_basics_proto = (
+    ("B",  "protocol_version"),
+    ("z",  "server_version"),
+    ("I",  "server_thread_id"),
+    ("8s", "auth_plugin_data_part1"),
+    ("x",  None),
+    ("H",  "capabilities_lower"),
+)
+
+_basics_expr, Basics = _parse_proto_desc(_basics_proto, "Basics")
+
+# Define extended protocol
+_additional_proto = (
+    ("B",   'character_set'),
+    ("H",   'status_flags'),
+    ("H",   'capabilities_upper'),
+    ("B",   'auth_plugin_data_length'),
+    ("10x", None),
+)
+
+_additional_expr, Additional = _parse_proto_desc(_additional_proto, "Additional")
+
+
+def parse_basics(data):
+    expanded_basics_expr = _expand_expression(_basics_expr, data)
+    size = _struct.calcsize(expanded_basics_expr)
+    parsed = _parse(expanded_basics_expr, Basics, data)
+    return size, parsed
+
+def parse_additional(data):
+    size = _struct.calcsize(_additional_expr)
+    parsed = _parse(_additional_expr, Additional, data)
+    return size, parsed
+

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -570,26 +570,8 @@ class Connection(object):
         self.cert = None
         self.ca = None
 
-
         if compress or named_pipe:
             raise NotImplementedError("compress and named_pipe arguments are not supported")
-
-        self.ssl = self._init_ssl(ssl)
-        self._read_config(read_default_group, read_default_file)
-
-        if use_unicode is None and sys.version_info[0] > 2:
-            use_unicode = True
-
-        if self.charset:
-            self.use_unicode = True
-        else:
-            self.charset = DEFAULT_CHARSET
-            self.use_unicode = False
-
-        if use_unicode is not None:
-            self.use_unicode = use_unicode
-
-        self.encoding = charset_by_name(self.charset).encoding
 
         self.cursorclass = cursorclass
         self.connect_timeout = connect_timeout
@@ -605,6 +587,12 @@ class Connection(object):
         self.decoders = conv
         self.sql_mode = sql_mode
         self.init_command = init_command
+
+        # Initialise aspects of the connection
+        self.ssl = self._init_ssl(ssl)
+        self._read_config(read_default_group, read_default_file)
+        self._init_char_encoding(use_unicode)
+
         self._connect()
 
     def _init_ssl(self, ssl):
@@ -649,6 +637,19 @@ class Connection(object):
             self.unix_socket = _config("socket", self.unix_socket)
             self.charset = _config("default-character-set", self.charset)
 
+    def _init_char_encoding(self, force_unicode=None):
+        if force_unicode is not None:
+            self.use_unicode = force_unicode
+        elif sys.version_info[0] > 2:
+            self.use_unicode = True
+        else:
+            self.use_unicode = bool(self.charset)
+
+        if not self.charset:
+            self.charset = DEFAULT_CHARSET
+
+        self.encoding = charset_by_name(self.charset).encoding
+
     def close(self):
         ''' Send the quit message and close the socket '''
         if self.socket is None:
@@ -678,10 +679,16 @@ class Connection(object):
         self._rfile = None
 
     def autocommit(self, value):
+        ac_vars = self._autocommit_vars(value)
+        self._set_variables(ac_vars)
+
+    def _autocommit_vars(self, value):
         self.autocommit_mode = bool(value)
         current = self.get_autocommit()
-        if value != current:
-            self._send_autocommit_mode()
+
+        if value == current:
+            return []
+        return [("AUTOCOMMIT", self.autocommit_mode)]
 
     def get_autocommit(self):
         return bool(self.server_status &
@@ -695,26 +702,34 @@ class Connection(object):
         self.server_status = ok.server_status
         return ok
 
-    def _send_autocommit_mode(self):
-        ''' Set whether or not to commit after every execute() '''
-        self._execute_command(COMMAND.COM_QUERY, "SET AUTOCOMMIT = %s" %
-                              self.escape(self.autocommit_mode))
-        self._read_ok_packet()
+    def _set_variables(self, pairs):
+        if not pairs:
+            return
+        sql = self._set_variables_sql(pairs)
+        self._execute_query(sql)
+
+    def _set_variables_sql(self, pairs):
+        '''Form sql to set a collection of variables.'''
+        if not pairs:
+            return ''
+        parts = []
+        for variable, value in pairs:
+            parts.append("%s = %s" % (variable, self.escape(value)))
+        query = "SET " + ", ".join(parts)
+
+        return query
 
     def begin(self):
         """Begin transaction."""
-        self._execute_command(COMMAND.COM_QUERY, "BEGIN")
-        self._read_ok_packet()
+        self._execute_query("BEGIN")
 
     def commit(self):
         ''' Commit changes to stable storage '''
-        self._execute_command(COMMAND.COM_QUERY, "COMMIT")
-        self._read_ok_packet()
+        self._execute_query("COMMIT")
 
     def rollback(self):
         ''' Roll back the current transaction '''
-        self._execute_command(COMMAND.COM_QUERY, "ROLLBACK")
-        self._read_ok_packet()
+        self._execute_query("ROLLBACK")
 
     def show_warnings(self):
         """SHOW WARNINGS"""
@@ -805,37 +820,43 @@ class Connection(object):
         # Make sure charset is supported.
         encoding = charset_by_name(charset).encoding
 
-        self._execute_command(COMMAND.COM_QUERY, "SET NAMES %s" % self.escape(charset))
-        self._read_packet()
+        self._set_variables([("NAMES", charset)])
+
         self.charset = charset
         self.encoding = encoding
+
+    def _get_socket(self):
+
+        sock = None
+        if self.unix_socket and self.host in ('localhost', '127.0.0.1'):
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(self.connect_timeout)
+            sock.connect(self.unix_socket)
+            self.host_info = "Localhost via UNIX socket"
+            if DEBUG: print('connected using unix_socket')
+        else:
+            while True:
+                try:
+                    sock = socket.create_connection(
+                        (self.host, self.port), self.connect_timeout)
+                    break
+                except (OSError, IOError) as e:
+                    if e.errno == errno.EINTR:
+                        continue
+                    raise
+            self.host_info = "socket %s:%d" % (self.host, self.port)
+            if DEBUG: print('connected using socket')
+
+        sock.settimeout(None)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        if self.no_delay:
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        return sock
 
     def _connect(self):
         sock = None
         try:
-            if self.unix_socket and self.host in ('localhost', '127.0.0.1'):
-                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                sock.settimeout(self.connect_timeout)
-                sock.connect(self.unix_socket)
-                self.host_info = "Localhost via UNIX socket"
-                if DEBUG: print('connected using unix_socket')
-            else:
-                while True:
-                    try:
-                        sock = socket.create_connection(
-                            (self.host, self.port), self.connect_timeout)
-                        break
-                    except (OSError, IOError) as e:
-                        if e.errno == errno.EINTR:
-                            continue
-                        raise
-                self.host_info = "socket %s:%d" % (self.host, self.port)
-                if DEBUG: print('connected using socket')
-            sock.settimeout(None)
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-            if self.no_delay:
-                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            self.socket = sock
+            self.socket = sock = self._get_socket()
             self._rfile = _makefile(sock, 'rb')
 
             # Server --> Client
@@ -844,18 +865,8 @@ class Connection(object):
             # Client --> Server
             self._request_authentication()
 
-
-            if self.sql_mode is not None:
-                c = self.cursor()
-                c.execute("SET sql_mode=%s", (self.sql_mode,))
-
-            if self.autocommit_mode is not None:
-                self.autocommit(self.autocommit_mode)
-
-            if self.init_command is not None:
-                c = self.cursor()
-                c.execute(self.init_command)
-                self.commit()
+            # Send initialisation query
+            self._send_init_query()
 
         except BaseException as e:
             self._rfile = None
@@ -970,6 +981,11 @@ class Connection(object):
                 break
             seq_id += 1
 
+    def _execute_query(self, query):
+        """ Execute a query """
+        self._execute_command(COMMAND.COM_QUERY, query)
+        self._read_ok_packet()
+
     def _client_flag_for_features(self):
 
         client_flag = CLIENT.CAPABILITIES | CLIENT.MULTI_STATEMENTS
@@ -1043,6 +1059,22 @@ class Connection(object):
             data = pack_int24(len(data)) + int2byte(next_packet) + data
             self._write_bytes(data)
             auth_packet = self._read_packet()
+
+    def _send_init_query(self):
+        sql_var = []
+        if self.sql_mode is not None:
+            sql_var.append(('sql_mode', self.sql_mode))
+
+        if self.autocommit_mode is not None:
+            sql_var.extend(self._autocommit_vars(self.autocommit_mode))
+
+        init_vars_sql = self._set_variables_sql(sql_var)
+        self._execute_query(init_vars_sql)
+
+        if self.init_command is not None:
+            c = self.cursor()
+            c.execute(self.init_command)
+            self.commit()
 
     # _mysql support
     def thread_id(self):

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -36,7 +36,6 @@ except ImportError:
     DEFAULT_USER = None
 
 
-import _connection_protocol
 
 from .charset import MBLENGTH, charset_by_name, charset_by_id
 from .cursors import Cursor
@@ -49,6 +48,7 @@ from .err import (
     InterfaceError, DataError, DatabaseError, OperationalError,
     IntegrityError, InternalError, NotSupportedError, ProgrammingError)
 from . import err
+from . import _connection_protocol
 
 _py_version = sys.version_info[:2]
 


### PR DESCRIPTION
This pull request is focused on performance - particularly for an environment with high connection rates and, in some situations, high latency between database and client.

The changes include:
 - Refactoring the Connection class' `__init__`
 - Work on parsing the server information
 - Accumulation of variables which require setting on establishment of connection
 - Capability to defer any setup sql and prepend it to the user's first query.

Practically the deferred mode seems to give reasonable performance improvements - even to a locally hosted database.

Apologies for a fairly large change set - I've tried to prepare the four commits which make up the change to be reasonably logical steps through the implementation of the change.  The implementation is pretty complete - but there are a few rough edges/missing tests.  

At this point I'd like to get some opinions on the approach and what you'd like to see to have it accepted by the project.

Thanks for taking the time to look,
Dave