### PR TITLE
Allowing to omit the Certificate Authority (CA) parameter ( issue 252 )

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -990,6 +990,14 @@ class Connection(object):
         next_packet = 1
 
         if self.ssl:
+            
+            # [ https://docs.python.org/2/library/ssl.html#ssl.wrap_socket ]
+            ca_certs = self.ca
+            if ca_certs is None:
+                cert_reqs = ssl.CERT_NONE
+            else: # "require and validate"
+                cert_reqs = ssl.CERT_REQUIRED
+            
             data = pack_int24(len(data_init)) + int2byte(next_packet) + data_init
             next_packet += 1
 
@@ -999,8 +1007,10 @@ class Connection(object):
             self.socket = ssl.wrap_socket(self.socket, keyfile=self.key,
                                           certfile=self.cert,
                                           ssl_version=ssl.PROTOCOL_TLSv1,
-                                          cert_reqs=ssl.CERT_REQUIRED,
-                                          ca_certs=self.ca)
+                                            ##  cert_reqs=ssl.CERT_REQUIRED,
+                                            ##  ca_certs=self.ca)
+                                          cert_reqs=cert_reqs, 
+                                          ca_certs=ca_certs )
             self._rfile = _makefile(self.socket, 'rb')
 
         data = data_init + self.user + b'\0' + \


### PR DESCRIPTION
Hi Guys,

Hopefully would be a no-brainer:
[ https://github.com/PyMySQL/PyMySQL/issues/252 ]

In MySQLdb, it is possible to omit the Certificate Authority (CA) parameter, e.g. { 'ssl' : { 'key' : 'somefile', 'cert' : 'someotherfile'} }, so that we may still have an encrypted connection with a custom ( or expired ) CA file ; sometimes when the server identity is known (e.g. local network) but encryption is still desired, this option may prove itself useful.

Therefore, I suggest to change connections.py::_request_authentication() to support that option.