### PR TITLE
Allow port to be a string

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -606,7 +606,7 @@ class Connection(object):
             charset = _config("default-character-set", charset)
 
         self.host = host
-        self.port = port
+        self.port = int(port)
         self.user = user or DEFAULT_USER
         self.password = password or ""
         self.db = database


### PR DESCRIPTION
This allows the port argument in the Connection constructor to be a string. For example:

```
Connection(port="3306")
```