### PR TITLE
Add mogrify to Cursor, which returns the exact string to be executed

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -103,12 +103,14 @@ class Cursor(object):
             #Worst case it will throw a Value error
             return conn.escape(args)
 
-    def execute(self, query, args=None):
-        '''Execute a query'''
-        conn = self._get_db()
+    def mogrify(self, query, args=None):
+        """
+        Returns the exact string that is sent to the database by calling the
+        execute() method.
 
-        while self.nextset():
-            pass
+        This method follows the extension to the DB API 2.0 followed by Psycopg.
+        """
+        conn = self._get_db()
 
         if PY2:  # Use bytes on Python 2 always
             encoding = conn.encoding
@@ -130,6 +132,15 @@ class Cursor(object):
 
         if args is not None:
             query = query % self._escape_args(args, conn)
+
+        return query
+
+    def execute(self, query, args=None):
+        '''Execute a query'''
+        while self.nextset():
+            pass
+
+        query = self.mogrify(query, args)
 
         result = self._query(query)
         self._executed = query


### PR DESCRIPTION
There is some need to have a method that returns the exact string that is passed to the DB in SQL cursors. Some of the discussions include:

* http://stackoverflow.com/questions/3748295/getting-the-sql-from-a-django-queryset
* http://stackoverflow.com/questions/1074212/show-the-sql-django-is-running
* http://stackoverflow.com/questions/5266430/how-to-see-the-real-sql-query-in-python-cursor-execute

Django does not have such feature. [Ticket 17741](https://code.djangoproject.com/ticket/17741) tried to address this, but was not able since this is adapter-dependent:

> Django never actually interpolates the parameters: it sends the query and the parameters separately to the database adapter, which performs the appropriate operations [aaugustin (core developer)]

People have been using the internal `Cursor._executed` or `Cursor._last_executed`, [e.g. this answer](http://stackoverflow.com/a/5266873/931303) however, it requires hitting in DB.

This PR proposes an interface to retrieve the SQL to be executed without need to hit the DB. Notice that such feature **is not** contemplated in [DB API 2.0 (PEP249)](https://www.python.org/dev/peps/pep-0249/). However, [Psycopg has it implemented as an extension](http://initd.org/psycopg/docs/cursor.html#cursor.mogrify):

> mogrify(operation[, parameters])
> Return a query string after arguments binding. The string returned is exactly the one that would be sent to the database running the execute() method or similar. 
> The returned string is always a bytes string.
> ```python
>>> cur.mogrify("INSERT INTO test (num, data) VALUES (%s, %s)", (42, 'bar'))
"INSERT INTO test (num, data) VALUES (42, E'bar')"
```

This PR implements the same  interface. It uses the same name `mogrify`, consistent with Psycopg name. I don't think it is a very useful name, since I would not get what it does by its name, but IMO changing it would only make sense if Psycopg would also change it.

Technically, the problem is trivial and the change in the code is minor. This PR creates a new method `Cursor.mogrify`, which contains the code responsible for building the statement from `execute` to `mogrify`. `execute` calls `mogrify` to construct such query.