### PR TITLE
Set the 'charset' in the example for starting a connection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,7 @@ The following examples make use of a simple table
                                  user='user',
                                  passwd='passwd',
                                  db='db',
+                                 charset='utf8',
                                  cursorclass=pymysql.cursors.DictCursor)
 
     try:

--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ The following examples make use of a simple table
                                  user='user',
                                  passwd='passwd',
                                  db='db',
-                                 charset='utf8',
+                                 charset='utf8mb4',
                                  cursorclass=pymysql.cursors.DictCursor)
 
     try:


### PR DESCRIPTION
I think this change is important, as it might prevent some problems users could run into.