### PR TITLE
Don't try to iterate over none for warnings

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -299,8 +299,9 @@ class Cursor(object):
 
     def _show_warnings(self, conn):
         ws = conn.show_warnings()
-        for w in ws:
-            warnings.warn(w[-1], err.Warning, 4)
+        if ws is not None:
+            for w in ws:
+                warnings.warn(w[-1], err.Warning, 4)
 
     def __iter__(self):
         return iter(self.fetchone, None)

--- a/pymysql/tests/test_nextset.py
+++ b/pymysql/tests/test_nextset.py
@@ -55,5 +55,14 @@ class TestNextset(base.PyMySQLTestCase):
         self.assertEqual([(2,)], list(cur1))
         self.assertIsNone(cur1.nextset())
 
+    def test_multi_statement_warnings(self):
+        cursor = self.con.cursor()
+
+        try:
+            cursor.execute('DROP TABLE IF EXISTS a; '
+                           'DROP TABLE IF EXISTS b;')
+        except TypeError:
+            self.fail()
+
     #TODO: How about SSCursor and nextset?
     # It's very hard to implement correctly...


### PR DESCRIPTION
When executing multiple statements that generate warnings
`show_warnings()` may produce `None` which `_show_warnings()` was trying to
iterate over.