### PR TITLE
only set no_delay on TCP sockets

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -839,10 +839,10 @@ class Connection(object):
                         raise
                 self.host_info = "socket %s:%d" % (self.host, self.port)
                 if DEBUG: print('connected using socket')
+                if self.no_delay:
+                    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             sock.settimeout(None)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-            if self.no_delay:
-                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.socket = sock
             self._rfile = _makefile(sock, 'rb')
             self._get_server_information()


### PR DESCRIPTION
otherwise and exception is thrown on when connecting to unix_socket
([Errno 95] Operation not supported).

created databases and set connection file as follows. 

<pre>
cat pymysql/tests/databases.json
 [
    {"host": "localhost", "unix_socket": "/tmp/s.sock", "user": "root", "passwd": "", "db": "test_pymysql",  "use_unicode": true, "local_infile": true},
    {"host": "localhost", "unix_socket": "/tmp/s.sock", "user": "root", "passwd": "", "db": "test_pymysql2" }
]

Then ran tox

<pre>
======================================================================
ERROR: test_utf8mb4 (pymysql.tests.test_connection.TestConnection)
This test requires MySQL >= 5.5
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dan/software_projects/PyMySQL/pymysql/tests/base.py", line 41, in setUp
    self.connections.append(pymysql.connect(**params))
  File "/home/dan/software_projects/PyMySQL/pymysql/__init__.py", line 88, in Connect
    return Connection(*args, **kwargs)
  File "/home/dan/software_projects/PyMySQL/pymysql/connections.py", line 655, in __init__
    self._connect()
  File "/home/dan/software_projects/PyMySQL/pymysql/connections.py", line 880, in _connect
    raise exc
pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on u'localhost' ([Errno 95] Operation not supported)")
</pre>