### PR TITLE
expose get_server_version to return version tuple

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -15,6 +15,7 @@ import struct
 import sys
 import traceback
 import warnings
+import re
 
 from .charset import MBLENGTH, charset_by_name, charset_by_id
 from .cursors import Cursor
@@ -1065,6 +1066,11 @@ class Connection(object):
 
         server_end = data.find(int2byte(0), i)
         self.server_version = data[i:server_end].decode('latin1')
+        self.server_version_tuple = tuple(
+            (int(dig) if dig is not None else 0)
+            for dig in
+            re.match(r'(\d+)\.(\d+)\.(\d+)', self.server_version).group(1, 2, 3)
+        )
         i = server_end + 1
 
         self.server_thread_id = struct.unpack('<I', data[i:i+4])
@@ -1099,6 +1105,9 @@ class Connection(object):
 
     def get_server_info(self):
         return self.server_version
+
+    def get_server_version(self):
+        return self.server_version_tuple
 
     Warning = err.Warning
     Error = err.Error

--- a/pymysql/tests/base.py
+++ b/pymysql/tests/base.py
@@ -1,7 +1,6 @@
 import gc
 import json
 import os
-import re
 import warnings
 
 import unittest2
@@ -32,12 +31,7 @@ class PyMySQLTestCase(unittest2.TestCase):
             if self.mysql_server_is(conn, (5, 6, 4)):
                 # do something for MySQL 5.6.4 and above
         """
-        server_version = conn.get_server_info()
-        server_version_tuple = tuple(
-            (int(dig) if dig is not None else 0)
-            for dig in
-            re.match(r'(\d+)\.(\d+)\.(\d+)', server_version).group(1, 2, 3)
-        )
+        server_version = conn.get_server_version()
         return server_version_tuple >= version_tuple
 
     def setUp(self):

--- a/pymysql/tests/base.py
+++ b/pymysql/tests/base.py
@@ -32,7 +32,7 @@ class PyMySQLTestCase(unittest2.TestCase):
                 # do something for MySQL 5.6.4 and above
         """
         server_version = conn.get_server_version()
-        return server_version_tuple >= version_tuple
+        return server_version >= version_tuple
 
     def setUp(self):
         self.connections = []


### PR DESCRIPTION
Seemed like such a good use of a tuple in the text may as well expose it.

I haven't looked where the documentation is generated from.