### PR TITLE
Address encoding issues with mixed str/bytes in executemany and with iterables.

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -95,9 +95,7 @@ class Cursor(object):
         return self._nextset(False)
 
     def _ensure_bytes(self, x, encoding=None):
-        if not PY2:
-            return x
-        if isinstance(x, unicode):
+        if isinstance(x, text_type):
             x = x.encode(encoding)
         elif isinstance(x, (tuple, list)):
             x = type(x)(self._ensure_bytes(v, encoding=encoding) for v in x)

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -176,6 +176,8 @@ class Cursor(object):
         escape = self._escape_args
         if isinstance(prefix, text_type):
             prefix = prefix.encode(encoding)
+        if PY2 and isinstance(values, text_type):
+            values = values.encode(encoding)
         if isinstance(postfix, text_type):
             postfix = postfix.encode(encoding)
         sql = bytearray(prefix)

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import
+from functools import partial
 import re
 import warnings
 
@@ -93,14 +94,32 @@ class Cursor(object):
     def nextset(self):
         return self._nextset(False)
 
+    def _ensure_bytes(self, x, encoding=None):
+        if not PY2:
+            return x
+        if isinstance(x, unicode):
+            x = x.encode(encoding)
+        elif isinstance(x, (tuple, list)):
+            x = type(x)(self._ensure_bytes(v, encoding=encoding) for v in x)
+        return x
+
     def _escape_args(self, args, conn):
+        ensure_bytes = partial(self._ensure_bytes, encoding=conn.encoding)
+
         if isinstance(args, (tuple, list)):
+            if PY2:
+                args = tuple(map(ensure_bytes, args))
             return tuple(conn.escape(arg) for arg in args)
         elif isinstance(args, dict):
+            if PY2:
+                args = dict((ensure_bytes(key), ensure_bytes(val)) for
+                            (key, val) in args.items())
             return dict((key, conn.escape(val)) for (key, val) in args.items())
         else:
-            #If it's not a dictionary let's try escaping it anyways.
-            #Worst case it will throw a Value error
+            # If it's not a dictionary let's try escaping it anyways.
+            # Worst case it will throw a Value error
+            if PY2:
+                ensure_bytes(args)
             return conn.escape(args)
 
     def mogrify(self, query, args=None):
@@ -111,24 +130,8 @@ class Cursor(object):
         This method follows the extension to the DB API 2.0 followed by Psycopg.
         """
         conn = self._get_db()
-
         if PY2:  # Use bytes on Python 2 always
-            encoding = conn.encoding
-
-            def ensure_bytes(x):
-                if isinstance(x, unicode):
-                    x = x.encode(encoding)
-                return x
-
-            query = ensure_bytes(query)
-
-            if args is not None:
-                if isinstance(args, (tuple, list)):
-                    args = tuple(map(ensure_bytes, args))
-                elif isinstance(args, dict):
-                    args = dict((ensure_bytes(key), ensure_bytes(val)) for (key, val) in args.items())
-                else:
-                    args = ensure_bytes(args)
+            query = self._ensure_bytes(query, encoding=conn.encoding)
 
         if args is not None:
             query = query % self._escape_args(args, conn)

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -413,6 +413,7 @@ class TestGitHubIssues(base.PyMySQLTestCase):
             "engine=InnoDB default charset=utf8")
 
         sql = "insert into issue363 (value_1, value_2) values (%s, %s)"
+        usql = u"insert into issue363 (value_1, value_2) values (%s, %s)"
         values = [b"\x00\xff\x00", u"\xe4\xf6\xfc"]
 
         # test single insert and select
@@ -421,8 +422,14 @@ class TestGitHubIssues(base.PyMySQLTestCase):
         cur.execute("select * from issue363")
         self.assertEqual(cur.fetchone(), tuple(values))
 
+        # test single insert unicode query
+        cur.execute(usql, args=values)
+
         # test multi insert and select
-        cur.executemany(sql, args=[values, values, values])
+        cur.executemany(sql, args=(values, values, values))
         cur.execute("select * from issue363")
         for row in cur.fetchall():
             self.assertEqual(row, tuple(values))
+
+        # test multi insert with unicode query
+        cur.executemany(usql, args=(values, values, values))

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -377,3 +377,52 @@ class TestGitHubIssues(base.PyMySQLTestCase):
                     warnings.filterwarnings("ignore")
                     cur.execute('drop table if exists test_field_count')
 
+    def test_issue_321(self):
+        """ Test iterable as query argument. """
+        conn = pymysql.connect(charset="utf8", **self.databases[0])
+        self.safe_create_table(
+            conn, "issue321",
+            "create table issue321 (value_1 varchar(1), value_2 varchar(1))")
+
+        sql_insert = "insert into issue321 (value_1, value_2) values (%s, %s)"
+        sql_dict_insert = ("insert into issue321 (value_1, value_2) "
+                           "values (%(value_1)s, %(value_2)s)")
+        sql_select = ("select * from issue321 where "
+                      "value_1 in %s and value_2=%s")
+        data = [
+            [(u"a", ), u"\u0430"],
+            [[u"b"], u"\u0430"],
+            {"value_1": [[u"c"]], "value_2": u"\u0430"}
+        ]
+        cur = conn.cursor()
+        self.assertEqual(cur.execute(sql_insert, data[0]), 1)
+        self.assertEqual(cur.execute(sql_insert, data[1]), 1)
+        self.assertEqual(cur.execute(sql_dict_insert, data[2]), 1)
+        self.assertEqual(
+            cur.execute(sql_select, [(u"a", u"b", u"c"), u"\u0430"]), 3)
+        self.assertEqual(cur.fetchone(), (u"a", u"\u0430"))
+        self.assertEqual(cur.fetchone(), (u"b", u"\u0430"))
+        self.assertEqual(cur.fetchone(), (u"c", u"\u0430"))
+
+    def test_issue_364(self):
+        """ Test mixed unicode/binary arguments in executemany. """
+        conn = pymysql.connect(charset="utf8", **self.databases[0])
+        self.safe_create_table(
+            conn, "issue363",
+            "create table issue363 (value_1 binary(3), value_2 varchar(3)) "
+            "engine=InnoDB default charset=utf8")
+
+        sql = "insert into issue363 (value_1, value_2) values (%s, %s)"
+        values = [b"\x00\xff\x00", u"\xe4\xf6\xfc"]
+
+        # test single insert and select
+        cur = conn.cursor()
+        cur.execute(sql, args=values)
+        cur.execute("select * from issue363")
+        self.assertEqual(cur.fetchone(), tuple(values))
+
+        # test multi insert and select
+        cur.executemany(sql, args=[values, values, values])
+        cur.execute("select * from issue363")
+        for row in cur.fetchall():
+            self.assertEqual(row, tuple(values))


### PR DESCRIPTION
This should fix both #321 and #364.

I've incorporated the changes from #364 and hopefully addressed the review feedback. Since both of these issues touched the same code paths, one of them would have to be rebased on top of the other one.

Basically this pulls out the special PY2 handling out of the execute/mogrify function and also applies it to the executemany function. This all feels like a bit of a hack, but I don't know enough about the code to figure out how to better fix this. Pointers welcome :)