### PR TITLE
Add MySQL-5.6 and 5.7 to test suite

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,8 @@
 branch = True
 source =
     pymysql
-
+omit = pymysql/test/*
+       pymysql/tests/thirdparty/test_MySQLdb/*
 
 [report]
 exclude_lines =

--- a/.travis.databases.json
+++ b/.travis.databases.json
@@ -1,4 +1,4 @@
 [
-    {"host": "localhost", "user": "root", "passwd": "", "db": "test_pymysql",  "use_unicode": true, "local_infile": true},
-    {"host": "localhost", "user": "root", "passwd": "", "db": "test_pymysql2" }
+    {"host": "localhost", "unix_socket": "/var/run/mysqld/mysqld.sock", "user": "root", "passwd": "", "db": "test_pymysql",  "use_unicode": true, "local_infile": true},
+    {"host": "localhost", "port": 3306, "user": "root", "passwd": "", "db": "test_pymysql2" }
 ]

--- a/.travis.databases.json
+++ b/.travis.databases.json
@@ -1,4 +1,4 @@
 [
     {"host": "localhost", "unix_socket": "/var/run/mysqld/mysqld.sock", "user": "root", "passwd": "", "db": "test_pymysql",  "use_unicode": true, "local_infile": true},
-    {"host": "localhost", "port": 3306, "user": "root", "passwd": "", "db": "test_pymysql2" }
+    {"host": "127.0.0.1", "port": 3306, "user": "travis_pymysql2", "password": "some password", "db": "test_pymysql2" }
 ]

--- a/.travis.initialize.db.sh
+++ b/.travis.initialize.db.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+#debug
+set -x
+#verbose
+set -v
+
+if [ ! -z "${DB}" ]; then
+    F=mysql-${DB}-linux-glibc2.5-x86_64
+    mkdir -p ${HOME}/mysql
+    P=${HOME}/mysql/${F} 
+    if [ ! -d "${P}" ]; then
+        wget http://cdn.mysql.com/Downloads/MySQL-${DB%.*}/${F}.tar.gz -O - | tar -zxf - --directory=${HOME}/mysql 
+    fi
+    if [ -f "${P}"/my.cnf ]; then
+        O="--defaults-file=${P}/my.cnf" 
+    fi
+    if [ -x "${P}"/scripts/mysql_install_db ]; then
+        I=${P}/scripts/mysql_install_db 
+        O="--defaults-file=${P}/my.cnf" 
+    else
+        I=${P}/bin/mysqld
+        IO=" --initialize " 
+        O="--no-defaults " 
+    fi
+    ${I} ${O} ${IO} --basedir=${P} --datadir=${HOME}/db-"${DB}" --log-error=/tmp/mysql.err
+    PWLINE=$(grep 'A temporary password is generated for root@localhost:' /tmp/mysql.err)
+    PASSWD=${PWLINE##* }
+    if [ -x ${P}/bin/mysql_ssl_rsa_setup ]; then
+        ${P}/bin/mysql_ssl_rsa_setup --datadir=${HOME}/db-"${DB}"
+    fi
+    ${P}/bin/mysqld_safe ${O} --ledir=/ --mysqld=${P}/bin/mysqld  --datadir=${HOME}/db-${DB} --socket=/tmp/mysql.sock --port 3307 --innodb-buffer-pool-size=200M  --lc-messages-dir=${P}/share --plugin-dir=${P}/lib/plugin/ --log-error=/tmp/mysql.err &
+    sleep 5
+    cat /tmp/mysql.err
+    if [ ! -z "${PASSWD}" ]; then
+        ${P}/bin/mysql -S /tmp/mysql.sock -u root -p"${PASSWD}" --connect-expired-password -e "SET PASSWORD = PASSWORD('')"
+    fi
+    mysql -S /tmp/mysql.sock -u root -e "create user ${USER}@localhost; create user ${USER}@'%'; grant all on *.* to  ${USER}@localhost WITH GRANT OPTION;grant all on *.* to  ${USER}@'%' WITH GRANT OPTION;"
+    sed -e 's/3306/3307/g' -e 's:/var/run/mysqld/mysqld.sock:/tmp/mysql.sock:g' .travis.databases.json > pymysql/tests/databases.json
+    echo -e "[client]\nsocket = /tmp/mysql.sock\n" > "${HOME}"/.my.cnf 
+else
+    cp .travis.databases.json pymysql/tests/databases.json
+fi

--- a/.travis.initialize.db.sh
+++ b/.travis.initialize.db.sh
@@ -6,6 +6,9 @@ set -x
 set -v
 
 if [ ! -z "${DB}" ]; then
+    # disable existing database server in case of accidential connection
+    mysql -u root -e 'drop user travis@localhost; drop user root@localhost; drop user travis; create user super@localhost; grant all on super@localhost'
+    mysql -u super -e 'drop user root'
     F=mysql-${DB}-linux-glibc2.5-x86_64
     mkdir -p ${HOME}/mysql
     P=${HOME}/mysql/${F} 
@@ -37,7 +40,7 @@ if [ ! -z "${DB}" ]; then
     fi
     mysql -S /tmp/mysql.sock -u root -e "create user ${USER}@localhost; create user ${USER}@'%'; grant all on *.* to  ${USER}@localhost WITH GRANT OPTION;grant all on *.* to  ${USER}@'%' WITH GRANT OPTION;"
     sed -e 's/3306/3307/g' -e 's:/var/run/mysqld/mysqld.sock:/tmp/mysql.sock:g' .travis.databases.json > pymysql/tests/databases.json
-    echo -e "[client]\nsocket = /tmp/mysql.sock\n" > "${HOME}"/.my.cnf 
+    echo -e "[client]\nsocket = /tmp/mysql.sock\n" > "${HOME}"/.my.cnf
 else
     cp .travis.databases.json pymysql/tests/databases.json
 fi

--- a/.travis.initialize.db.sh
+++ b/.travis.initialize.db.sh
@@ -7,7 +7,7 @@ set -v
 
 if [ ! -z "${DB}" ]; then
     # disable existing database server in case of accidential connection
-    mysql -u root -e 'drop user travis@localhost; drop user root@localhost; drop user travis; create user super@localhost; grant all on super@localhost'
+    mysql -u root -e 'drop user travis@localhost; drop user root@localhost; drop user travis; create user super@localhost; grant all on *.* to super@localhost with grant option'
     mysql -u super -e 'drop user root'
     F=mysql-${DB}-linux-glibc2.5-x86_64
     mkdir -p ${HOME}/mysql

--- a/.travis.initialize.db.sh
+++ b/.travis.initialize.db.sh
@@ -32,6 +32,9 @@ if [ ! -z "${DB}" ]; then
     if [ -x ${P}/bin/mysql_ssl_rsa_setup ]; then
         ${P}/bin/mysql_ssl_rsa_setup --datadir=${HOME}/db-"${DB}"
     fi
+     # sha256 password auth keys:
+     openssl genrsa -out "${P}"/private_key.pem 2048
+     openssl rsa -in "${P}"/private_key.pem -pubout -out "${P}"/public_key.pem
     ${P}/bin/mysqld_safe ${O} --ledir=/ --mysqld=${P}/bin/mysqld  --datadir=${HOME}/db-${DB} --socket=/tmp/mysql.sock --port 3307 --innodb-buffer-pool-size=200M  --lc-messages-dir=${P}/share --plugin-dir=${P}/lib/plugin/ --log-error=/tmp/mysql.err &
     while [ ! -S /tmp/mysql.sock  ]; do
        sleep 2

--- a/.travis.initialize.db.sh
+++ b/.travis.initialize.db.sh
@@ -33,7 +33,9 @@ if [ ! -z "${DB}" ]; then
         ${P}/bin/mysql_ssl_rsa_setup --datadir=${HOME}/db-"${DB}"
     fi
     ${P}/bin/mysqld_safe ${O} --ledir=/ --mysqld=${P}/bin/mysqld  --datadir=${HOME}/db-${DB} --socket=/tmp/mysql.sock --port 3307 --innodb-buffer-pool-size=200M  --lc-messages-dir=${P}/share --plugin-dir=${P}/lib/plugin/ --log-error=/tmp/mysql.err &
-    sleep 5
+    while [ ! -S /tmp/mysql.sock  ]; do
+       sleep 2
+    done
     cat /tmp/mysql.err
     if [ ! -z "${PASSWD}" ]; then
         ${P}/bin/mysql -S /tmp/mysql.sock -u root -p"${PASSWD}" --connect-expired-password -e "SET PASSWORD = PASSWORD('')"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
               apt:
                  packages:
                      - libaio-dev
-          python: 3.3
+          python: 3.4
         - env:
              - TOX_ENV=py34
              - DB=5.7.8-rc

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,7 @@ install:
     - pip install -U tox
 
 before_script:
-    - if [ ! -z "${DB}" ]; then
-          ./.travis.initialize.db.sh;
-      fi
+    - ./.travis.initialize.db.sh;
     - "mysql -e 'create database test_pymysql  DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'"
     - "mysql -e 'create database test_pymysql2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'"
     - mysql -u root -e "create user travis_pymysql2 identified by 'some password'; grant all on test_pymysql2.* to travis_pymysql2;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,10 @@ before_script:
       fi
     - "mysql -e 'create database test_pymysql  DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'"
     - "mysql -e 'create database test_pymysql2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'"
+    - mysql -u root -e "create user travis_pymysql2 identified by 'some password'; grant all on test_pymysql2.* to travis_pymysql2;"
+    - mysql -u root -e "create user travis_pymysql2@localhost identified by 'some password'; grant all on test_pymysql2.* to travis_pymysql2@localhost;"
     - "mysql -e 'select VERSION();'"
+    - rm -f ~/.my.cnf # set in package downloads for the above commands - we should be using database.json however
 
 script:
     - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,12 @@ install:
 
 before_script:
     - ./.travis.initialize.db.sh;
-    - "mysql -e 'create database test_pymysql  DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'"
-    - "mysql -e 'create database test_pymysql2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'"
+    - mysql -e 'create database test_pymysql  DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'
+    - mysql -e 'create database test_pymysql2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'
     - mysql -u root -e "create user travis_pymysql2 identified by 'some password'; grant all on test_pymysql2.* to travis_pymysql2;"
     - mysql -u root -e "create user travis_pymysql2@localhost identified by 'some password'; grant all on test_pymysql2.* to travis_pymysql2@localhost;"
-    - "mysql -e 'select VERSION();'"
-    - rm -f ~/.my.cnf # set in package downloads for the above commands - we should be using database.json however
+    - mysql -e 'select VERSION();'
+    - rm -f ~/.my.cnf # set in .travis.initialize.db.sh for the above commands - we should be using database.json however
 
 script:
     - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 language: python
 python: "3.4"
 cache:
-    directories:
-        - ${HOME}/mysql
     pip: true
 
 
@@ -34,7 +32,10 @@ matrix:
               apt:
                  packages:
                      - libaio-dev
-          python: 3.4
+          python: 3.3
+          cache:
+              directories:
+                  - ${HOME}/mysql
         - env:
              - TOX_ENV=py34
              - DB=5.7.8-rc
@@ -43,12 +44,15 @@ matrix:
                  packages:
                      - libaio-dev
           python: 3.4
+          cache:
+              directories:
+                  - ${HOME}/mysql
 
 # different py version from 5.6 and 5.7 as cache seems to be based on py version
 
 # http://dev.mysql.com/downloads/mysql/5.7.html has latest development release version
 
-# really only need libaio1 however libaio-dev is whitelisted for container builds and liaio1 isn't
+# really only need libaio1 for DB builds however libaio-dev is whitelisted for container builds and liaio1 isn't
 
 install:
     - pip install -U tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 sudo: false
 language: python
 python: "3.4"
+cache:
+    directories:
+        - ${HOME}/mysql
+    pip: true
+
+
 env:
     matrix:
         - TOX_ENV=py26
@@ -21,14 +27,42 @@ matrix:
         - addons:
              mariadb: 10.1
           env: TOX_ENV=py34
+        - env:
+             - TOX_ENV=py34
+             - DB=5.6.26
+          addons:
+              apt:
+                 packages:
+                     - libaio-dev
+          python: 3.3
+        - env:
+             - TOX_ENV=py34
+             - DB=5.7.8-rc
+          addons:
+              apt:
+                 packages:
+                     - libaio-dev
+          python: 3.4
+
+# different py version from 5.6 and 5.7 as cache seems to be based on py version
+
+# http://dev.mysql.com/downloads/mysql/5.7.html has latest development release version
+
+# really only need libaio1 however libaio-dev is whitelisted for container builds and liaio1 isn't
 
 install:
     - pip install -U tox
 
 before_script:
+    - if [ ! -z "${DB}" ]; then
+          ./.travis.initialize.db.sh;
+      fi
     - "mysql -e 'create database test_pymysql  DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'"
     - "mysql -e 'create database test_pymysql2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'"
     - "mysql -e 'select VERSION();'"
-    - cp .travis.databases.json pymysql/tests/databases.json
 
-script: tox -e $TOX_ENV
+script:
+    - tox -e $TOX_ENV
+
+after_failure:
+    - cat /tmp/mysql.err

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -651,7 +651,9 @@ class Connection(object):
         self.sql_mode = sql_mode
         self.init_command = init_command
         self.max_allowed_packet = max_allowed_packet
-        if not defer_connect:
+        if defer_connect:
+            self.socket = None
+        else:
             self.connect()
 
     def close(self):

--- a/pymysql/tests/test_SSCursor.py
+++ b/pymysql/tests/test_SSCursor.py
@@ -35,6 +35,7 @@ class TestSSCursor(base.PyMySQLTestCase):
                 'zone VARCHAR(64),'
                 'name VARCHAR(64))'))
 
+            conn.begin()
             # Test INSERT
             for i in data:
                 cursor.execute('INSERT INTO tz_data VALUES (%s, %s, %s)', i)

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -74,6 +74,13 @@ class TestConnection(base.PyMySQLTestCase):
         self.assertEqual(('foobar',), c.fetchone())
         conn.close()
 
+    def test_read_default_group(self):
+        conn = pymysql.connect(
+            read_default_group='client',
+            **self.databases[0]
+        )
+        self.assertTrue(conn.open)
+
 
 # A custom type and function to escape it
 class Foo(object):

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -73,6 +73,8 @@ class TestConnection(base.PyMySQLTestCase):
         c.execute('select "foobar";')
         self.assertEqual(('foobar',), c.fetchone())
         conn.close()
+        with self.assertRaises(pymysql.err.Error):
+            conn.ping(reconnect=False)
 
     def test_read_default_group(self):
         conn = pymysql.connect(
@@ -80,6 +82,30 @@ class TestConnection(base.PyMySQLTestCase):
             **self.databases[0]
         )
         self.assertTrue(conn.open)
+
+    def test_context(self):
+        with self.assertRaises(ValueError):
+            c = pymysql.connect(**self.databases[0])
+            with c as cur:
+                cur.execute('create table test ( a int )')
+                c.begin()
+                cur.execute('insert into test values ((1))')
+                raise ValueError('pseudo abort')
+                c.commit()
+        c = pymysql.connect(**self.databases[0])
+        with c as cur:
+            cur.execute('select count(*) from test')
+            self.assertEqual(0, cur.fetchone()[0])
+            cur.execute('insert into test values ((1))')
+        with c as cur:
+            cur.execute('select count(*) from test')
+            self.assertEqual(1,cur.fetchone()[0])
+            cur.execute('drop table test')
+
+    def test_set_charset(self):
+        c = pymysql.connect(**self.databases[0])
+        c.set_charset('utf8')
+        # TODO validate setting here
 
 
 # A custom type and function to escape it

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -126,6 +126,7 @@ class TestConnection(base.PyMySQLTestCase):
             c = pymysql.connect(defer_connect=True, **d)
             self.assertFalse(c.open)
             c.connect(sock)
+            c.close()
 
 
 # A custom type and function to escape it

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -90,7 +90,8 @@ class TestEscape(base.PyMySQLTestCase):
         cur = con.cursor()
 
         self.assertEqual(con.escape("foo'bar"), "'foo\\'bar'")
-        cur.execute("SET sql_mode='NO_BACKSLASH_ESCAPES'")
+        # added NO_AUTO_CREATE_USER as not including it in 5.7 generates warnings
+        cur.execute("SET sql_mode='NO_BACKSLASH_ESCAPES,NO_AUTO_CREATE_USER'")
         self.assertEqual(con.escape("foo'bar"), "'foo''bar'")
 
     def test_escape_builtin_encoders(self):

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -199,9 +199,9 @@ class TestNewIssues(base.PyMySQLTestCase):
             self.assertEqual(2013, e.args[0])
 
     def test_issue_36(self):
-        conn = self.connections[0]
+        # connection 0 is super user, connection 1 isn't
+        conn = self.connections[1]
         c = conn.cursor()
-        # kill connections[0]
         c.execute("show processlist")
         kill_id = None
         for row in c.fetchall():
@@ -212,7 +212,7 @@ class TestNewIssues(base.PyMySQLTestCase):
                 break
         self.assertEqual(kill_id, conn.thread_id())
         # now nuke the connection
-        self.connections[1].kill(kill_id)
+        self.connections[0].kill(kill_id)
         # make sure this connection has broken
         try:
             c.execute("show tables")
@@ -227,12 +227,12 @@ class TestNewIssues(base.PyMySQLTestCase):
             # Wait since Travis-CI sometimes fail this test.
             time.sleep(0.1)
 
-            c = self.connections[1].cursor()
+            c = self.connections[0].cursor()
             c.execute("show processlist")
             ids = [row[0] for row in c.fetchall()]
             self.assertFalse(kill_id in ids)
         finally:
-            del self.connections[0]
+            del self.connections[1]
 
     def test_issue_37(self):
         conn = self.connections[0]

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -419,21 +419,37 @@ class TestGitHubIssues(base.PyMySQLTestCase):
 
         # test single insert and select
         cur = conn.cursor()
-        cur.execute(sql, args=values)
+        if sys.version_info[0:2] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
+            with self.assertWarns(pymysql.err.Warning) as cm:
+                cur.execute(sql, args=values)
+        else:
+            cur.execute(sql, args=values)
         cur.execute("select * from issue364")
         self.assertEqual(cur.fetchone(), tuple(values))
 
         # test single insert unicode query
-        cur.execute(usql, args=values)
+        if sys.version_info[0:2] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
+            with self.assertWarns(pymysql.err.Warning) as cm:
+                cur.execute(usql, args=values)
+        else:
+            cur.execute(usql, args=values)
 
         # test multi insert and select
-        cur.executemany(sql, args=(values, values, values))
+        if sys.version_info[0:2] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
+            with self.assertWarns(pymysql.err.Warning) as cm:
+                cur.executemany(sql, args=(values, values, values))
+        else:
+            cur.executemany(sql, args=(values, values, values))
         cur.execute("select * from issue364")
         for row in cur.fetchall():
             self.assertEqual(row, tuple(values))
 
         # test multi insert with unicode query
-        cur.executemany(usql, args=(values, values, values))
+        if sys.version_info[0:2] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
+            with self.assertWarns(pymysql.err.Warning) as cm:
+                cur.executemany(usql, args=(values, values, values))
+        else:
+            cur.executemany(usql, args=(values, values, values))
 
     def test_issue_363(self):
         """ Test binary / geometry types. """
@@ -447,7 +463,7 @@ class TestGitHubIssues(base.PyMySQLTestCase):
 
         cur = conn.cursor()
         # FYI - not sure of 5.7.0 version
-        if sys.version_info[0:1] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
+        if sys.version_info[0:2] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
             with self.assertWarns(pymysql.err.Warning) as cm:
                 cur.execute("INSERT INTO issue363 (id, geom) VALUES ("
                             "1998, GeomFromText('LINESTRING(1.1 1.1,2.2 2.2)'))")
@@ -456,12 +472,20 @@ class TestGitHubIssues(base.PyMySQLTestCase):
                         "1998, GeomFromText('LINESTRING(1.1 1.1,2.2 2.2)'))")
 
         # select WKT
-        cur.execute("SELECT AsText(geom) FROM issue363")
+        if sys.version_info[0:2] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
+            with self.assertWarns(pymysql.err.Warning) as cm:
+                cur.execute("SELECT AsText(geom) FROM issue363")
+        else:
+            cur.execute("SELECT AsText(geom) FROM issue363")
         row = cur.fetchone()
         self.assertEqual(row, ("LINESTRING(1.1 1.1,2.2 2.2)", ))
 
         # select WKB
-        cur.execute("SELECT AsBinary(geom) FROM issue363")
+        if sys.version_info[0:2] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
+            with self.assertWarns(pymysql.err.Warning) as cm:
+                cur.execute("SELECT AsBinary(geom) FROM issue363")
+        else:
+            cur.execute("SELECT AsBinary(geom) FROM issue363")
         row = cur.fetchone()
         self.assertEqual(row,
                          (b"\x01\x02\x00\x00\x00\x02\x00\x00\x00"

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -76,7 +76,7 @@ class TestOldIssues(base.PyMySQLTestCase):
             warnings.filterwarnings("ignore")
             c.execute("drop table if exists test")
         c.execute("""CREATE TABLE `test` (`station` int(10) NOT NULL DEFAULT '0', `dh`
-datetime NOT NULL DEFAULT '0000-00-00 00:00:00', `echeance` int(1) NOT NULL
+datetime NOT NULL DEFAULT '2015-01-01 00:00:00', `echeance` int(1) NOT NULL
 DEFAULT '0', `me` double DEFAULT NULL, `mo` double DEFAULT NULL, PRIMARY
 KEY (`station`,`dh`,`echeance`)) ENGINE=MyISAM DEFAULT CHARSET=latin1;""")
         try:

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -1,6 +1,7 @@
 import datetime
 import time
 import warnings
+import sys
 
 import pymysql
 from pymysql.tests import base
@@ -445,8 +446,14 @@ class TestGitHubIssues(base.PyMySQLTestCase):
             "ENGINE=MyISAM default charset=utf8")
 
         cur = conn.cursor()
-        cur.execute("INSERT INTO issue363 (id, geom) VALUES ("
-                    "1998, GeomFromText('LINESTRING(1.1 1.1,2.2 2.2)'))")
+        # FYI - not sure of 5.7.0 version
+        if sys.version_info[0:1] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
+            with self.assertWarns(pymysql.err.Warning) as cm:
+                cur.execute("INSERT INTO issue363 (id, geom) VALUES ("
+                            "1998, GeomFromText('LINESTRING(1.1 1.1,2.2 2.2)'))")
+        else:
+            cur.execute("INSERT INTO issue363 (id, geom) VALUES ("
+                        "1998, GeomFromText('LINESTRING(1.1 1.1,2.2 2.2)'))")
 
         # select WKT
         cur.execute("SELECT AsText(geom) FROM issue363")

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -413,43 +413,27 @@ class TestGitHubIssues(base.PyMySQLTestCase):
             "create table issue364 (value_1 binary(3), value_2 varchar(3)) "
             "engine=InnoDB default charset=utf8")
 
-        sql = "insert into issue364 (value_1, value_2) values (%s, %s)"
+        sql = "insert into issue364 (value_1, value_2) values (_binary%s, _binary%s)"
         usql = u"insert into issue364 (value_1, value_2) values (_binary%s, _binary%s)"
         values = [b"\x00\xff\x00", u"\xe4\xf6\xfc"]
 
         # test single insert and select
         cur = conn.cursor()
-        if sys.version_info[0:2] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
-            with self.assertWarns(pymysql.err.Warning) as cm:
-                cur.execute(sql, args=values)
-        else:
-            cur.execute(sql, args=values)
+        cur.execute(sql, args=values)
         cur.execute("select * from issue364")
         self.assertEqual(cur.fetchone(), tuple(values))
 
         # test single insert unicode query
-        if sys.version_info[0:2] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
-            with self.assertWarns(pymysql.err.Warning) as cm:
-                cur.execute(usql, args=values)
-        else:
-            cur.execute(usql, args=values)
+        cur.execute(usql, args=values)
 
         # test multi insert and select
-        if sys.version_info[0:2] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
-            with self.assertWarns(pymysql.err.Warning) as cm:
-                cur.executemany(sql, args=(values, values, values))
-        else:
-            cur.executemany(sql, args=(values, values, values))
+        cur.executemany(sql, args=(values, values, values))
         cur.execute("select * from issue364")
         for row in cur.fetchall():
             self.assertEqual(row, tuple(values))
 
         # test multi insert with unicode query
-        if sys.version_info[0:2] >= (3,2) and self.mysql_server_is(conn, (5, 7, 0)):
-            with self.assertWarns(pymysql.err.Warning) as cm:
-                cur.executemany(usql, args=(values, values, values))
-        else:
-            cur.executemany(usql, args=(values, values, values))
+        cur.executemany(usql, args=(values, values, values))
 
     def test_issue_363(self):
         """ Test binary / geometry types. """

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -414,7 +414,7 @@ class TestGitHubIssues(base.PyMySQLTestCase):
             "engine=InnoDB default charset=utf8")
 
         sql = "insert into issue364 (value_1, value_2) values (%s, %s)"
-        usql = u"insert into issue364 (value_1, value_2) values (%s, %s)"
+        usql = u"insert into issue364 (value_1, value_2) values (_binary%s, _binary%s)"
         values = [b"\x00\xff\x00", u"\xe4\xf6\xfc"]
 
         # test single insert and select


### PR DESCRIPTION
MySQL-5.7 has some warnings in a couple of cases so the test cases have been modified.

Geom functions give warnings now was ST_{function} is the newer syntax so just accept the warnings for now.

#364 I'm not sure if silencing those warnings is correct.

For other tests I've worked around the constraints of 5.7 by altering the test in a compatible way to 5.0+ and haven't interfered with the objective of the test.