### PR TITLE
Fix url for coveralls badge - wrong branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ PyMySQL
 .. image:: https://travis-ci.org/PyMySQL/PyMySQL.svg?branch=master
    :target: https://travis-ci.org/PyMySQL/PyMySQL
 
-.. image:: https://coveralls.io/repos/PyMySQL/PyMySQL/badge.svg?branch=coveralls&service=github :target: https://coveralls.io/github/PyMySQL/PyMySQL?branch=coveralls
+.. image:: https://coveralls.io/repos/PyMySQL/PyMySQL/badge.svg?branch=master&service=github :target: https://coveralls.io/github/PyMySQL/PyMySQL?branch=master
 
 .. contents::
 


### PR DESCRIPTION
oops. Changed to repo, missed the branch.