### PR TITLE
Bump version_info

### DIFF
--- a/pymysql/__init__.py
+++ b/pymysql/__init__.py
@@ -100,7 +100,7 @@ def get_client_info():  # for MySQLdb compatibility
 connect = Connection = Connect
 
 # we include a doctored version_info here for MySQLdb compatibility
-version_info = (1,2,2,"final",0)
+version_info = (1,2,6,"final",0)
 
 NULL = "NULL"
 


### PR DESCRIPTION
This will allow Django to use DateTimeField with microseconds.
It checks the driver version here:
https://github.com/django/django/blob/master/django/db/backends/mysql/features.py#L53