### PR TITLE
Add NumPyDoc docstring to BaseCursor.execute

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -137,7 +137,25 @@ class Cursor(object):
         return query
 
     def execute(self, query, args=None):
-        '''Execute a query'''
+        """
+        Execute a query
+
+        Parameters
+        ----------
+        query : str
+            Query to execute on the server.
+        args : sequence or mapping, optional
+            Will be used with query
+
+        Returns
+        -------
+        int
+            Number of affected rows
+
+        Notes
+        -----
+        If args is a sequence, %s can be used as a placeholder in the query.
+        """
         while self.nextset():
             pass
 

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -144,7 +144,7 @@ class Cursor(object):
         ----------
         query : str
             Query to execute on the server.
-        args : sequence or mapping, optional
+        args : tuple, list or dict, optional
             Will be used with query
 
         Returns
@@ -155,6 +155,7 @@ class Cursor(object):
         Notes
         -----
         If args is a sequence, %s can be used as a placeholder in the query.
+        If args is a dict, %(name)s can be used as a placeholder in the query.
         """
         while self.nextset():
             pass


### PR DESCRIPTION
* Parameters explained
* Return value explained

NumPyDoc is a standard docstring format (see [guide](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)) which leads is very well readable in the source code, in the `help()`. It can also be used to generate beautiful documentation.

See the following examples  [`Lasagne/lasagne/layers/input.py`](https://github.com/Lasagne/Lasagne/blob/master/lasagne/layers/input.py) and [website docs](http://lasagne.readthedocs.org/en/latest/modules/layers.html)
