### PR TITLE
bit conversion converts to int not string

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -309,13 +309,8 @@ def through(x):
     return x
 
 
-#def convert_bit(b):
-#    b = "\x00" * (8 - len(b)) + b # pad w/ zeroes
-#    return struct.unpack(">Q", b)[0]
-#    
-#     the snippet above is right, but MySQLdb doesn't process bits,
-#     so we shouldn't either
-convert_bit = through
+def convert_bit(b):
+    return ord(b)
 
 
 def convert_characters(connection, field, data):

--- a/pymysql/tests/test_basic.py
+++ b/pymysql/tests/test_basic.py
@@ -27,7 +27,7 @@ class TestConversion(base.PyMySQLTestCase):
             c.execute("insert into test_datatypes (b,i,l,f,s,u,bb,d,dt,td,t,st) values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)", v)
             c.execute("select b,i,l,f,s,u,bb,d,dt,td,t,st from test_datatypes")
             r = c.fetchone()
-            self.assertEqual(util.int2byte(1), r[0])
+            self.assertEqual(1, r[0])
             self.assertEqual(v[1:10], r[1:10])
             self.assertEqual(datetime.timedelta(0, 60 * (v[10].hour * 60 + v[10].minute)), r[10])
             self.assertEqual(datetime.datetime(*v[-1][:6]), r[-1])


### PR DESCRIPTION
I have some legacy code to support that uses a bit field as a boolean. I am switching from oursql (which automatically converts bit fields to integers) to pymysql. The field is registered in SqlAlchemy as a Boolean field. It gets properly put into the database but when it comes out there is a type error saying `an integer is required (got bytes)`. Tests failing in SqlAlchemy drove me nuts until I realized pymysql simply does nothing to convert bit fields from strings to python values. Oursql converts bit fields to integers because it [recognizes](https://github.com/python-oursql/oursql/blob/master/oursqlx/statement.pyx#L537) there is probably no other use for it. Since no solution has been proposed other than to ignore the issue, I propose that we start with this one.

Thank you!