### PR TITLE
Rename connection class level socket attribute to _sock.

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -522,7 +522,7 @@ class Connection(object):
     connect().
     """
 
-    socket = None
+    _sock = None
     _auth_plugin_name = ''
 
     def __init__(self, host=None, user=None, password="",


### PR DESCRIPTION
This matches the renaming done in 93297cc5af45542d302fe11ef968621427ea60fd.

Without this there are sometimes errors during Python process shutdown and garbage collection inside the `__del__` method. The `__del__` starts with:
```
def __del__(self):
    if self._sock:
```
This sometimes throws an AttributeError for `self._sock`. I think what happens here, is that the instance level dict is cleared before the `__del__` method is invoked, so `_sock` isn't there anymore. The class level attribute ensures that there is a fallback, even with the instance `__dict__` already cleared out.