### PR TITLE
Changed the encoder resolution to use isinstance rather than type after running into some issues with support of extended native types (for example, int/str subclasses didn't work).

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -11,7 +11,12 @@ from .charset import charset_by_id, charset_to_encoding
 def escape_item(val, charset, mapping=None):
     if mapping is None:
         mapping = encoders
-    encoder = mapping.get(type(val))
+    for cls in mapping:
+        if isinstance(val, cls):
+            encoder = mapping[cls]
+            break
+    else:
+        encoder = None
 
     # Fallback to default when no encoder found
     if not encoder:


### PR DESCRIPTION
PyMySQL encodes query parameters; however, encoding extended native types (for example, `class A(int): pass`) doesn't work, because encoder resolution is done with `type` (i.e., `encoder = mapping.get(type(val))`).
This kinda goes against the whole "duck typing" principle of Python, where having an object which behaves exactly like a native `int` (or `str`, or anything else, for that matter), should work just as well.
I was able to fix the problem by monkey-patching PyMySQL in my code (i.e., `import pymysql.converters; pymysql.converters.encoders[A] = pymysql.converters.encoders[int]`), but I think the correct solution would be to use `isinstance` rather than `type` in PyMySQL's encoder resolution (which, by the way, is considered a better practice in any case).
Of course, it's fully backwards compatible and doesn't break any tests.
Anyway, thanks for a great project!