### PR TITLE
Catch KeyError from getpass.getuser()

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -35,7 +35,8 @@ try:
     import getpass
     DEFAULT_USER = getpass.getuser()
     del getpass
-except ImportError:
+except (ImportError, KeyError):
+    # KeyError occurs when there's no entry in OS database for a current user.
     DEFAULT_USER = None
 
 


### PR DESCRIPTION
KeyError occurs when there's no entry in OS user database for a current user. This is quite often the case for Docker containers.

Example traceback:

```
  File "/tmp/unpacked-eggs/pymysql.egg/pymysql/__init__.py", line 90, in <module>
    from pymysql import connections as _orig_conn
  File "/tmp/unpacked-eggs/pymysql.egg/pymysql/connections.py", line 34, in <module>
    DEFAULT_USER = getpass.getuser()
  File "/usr/lib/python2.7/getpass.py", line 158, in getuser
    return pwd.getpwuid(os.getuid())[0]
KeyError: 'getpwuid(): uid not found: 33333'
```