### PR TITLE
Add explicit convertion unicode objects to unicode

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -80,6 +80,8 @@ if PY2:
 
         Value should be bytes or unicode.
         """
+        if type(value) is str:
+            return _escape_unicode(value.decode('utf8'))
         if isinstance(value, unicode):
             return _escape_unicode(value)
         assert isinstance(value, (bytes, bytearray))

--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -70,7 +70,10 @@ def _escape_unicode(value, mapping=None):
 
     Value should be unicode
     """
-    value = unicode(value)
+    if PY2:
+        value = unicode(value)
+    else:
+        value = str(value, 'utf-8')
     return value.translate(_escape_table)
 
 if PY2:

--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -80,10 +80,10 @@ if PY2:
 
         Value should be bytes or unicode.
         """
-        if type(value) is str:
-            return _escape_unicode(value.decode('utf8'))
         if isinstance(value, unicode):
             return _escape_unicode(value)
+        elif type(value) is str:
+            return _escape_unicode(value.decode('utf8'))
         assert isinstance(value, (bytes, bytearray))
         value = value.replace('\\', '\\\\')
         value = value.replace('\0', '\\0')

--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -72,8 +72,6 @@ def _escape_unicode(value, mapping=None):
     """
     if PY2:
         value = unicode(value)
-    else:
-        value = str(value, 'utf-8')
     return value.translate(_escape_table)
 
 if PY2:

--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -70,6 +70,7 @@ def _escape_unicode(value, mapping=None):
 
     Value should be unicode
     """
+    value = unicode(value)
     return value.translate(_escape_table)
 
 if PY2:


### PR DESCRIPTION
Explicit convertion is required for Python 2 if object is detected as <type 'unicode'>, but it is not indeed, i.e. <class 'uuid.UUID'> objects are not <type 'unicode'> and thus don't have 'translate()' method. So they fail here.