### PR TITLE
Allow connecting to the DB from a specific network interface

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -535,7 +535,7 @@ class Connection(object):
                  autocommit=False, db=None, passwd=None, local_infile=False,
                  max_allowed_packet=16*1024*1024, defer_connect=False,
                  auth_plugin_map={}, read_timeout=None, write_timeout=None,
-                 bind=None):
+                 bind_address=None):
         """
         Establish a connection to the MySQL database. Accepts several
         arguments:
@@ -545,9 +545,9 @@ class Connection(object):
         password: Password to use.
         database: Database to use, None to not use a particular one.
         port: MySQL port to use, default is usually OK. (default: 3306)
-        bind: When the client has multiple network interfaces, specify
-            the interface from which to connect to the host. Argument
-            can be a hostname or an IP address.
+        bind_address: When the client has multiple network interfaces, specify
+            the interface from which to connect to the host. Argument can be
+            a hostname or an IP address.
         unix_socket: Optionally, you can use a unix socket rather than TCP/IP.
         charset: Charset you want to use.
         sql_mode: Default SQL_MODE to use.
@@ -636,7 +636,7 @@ class Connection(object):
             database = _config("database", database)
             unix_socket = _config("socket", unix_socket)
             port = int(_config("port", port))
-            bind = _config("bind-address", bind)
+            bind_address = _config("bind-address", bind_address)
             charset = _config("default-character-set", charset)
 
         self.host = host or "localhost"
@@ -645,9 +645,7 @@ class Connection(object):
         self.password = password or ""
         self.db = database
         self.unix_socket = unix_socket
-        if bind is not None and _py_version == (2, 6):
-            raise NotImplementedError("bind before connect is not supported in Python 2.6")
-        self.bind = bind
+        self.bind_address = bind_address
         if read_timeout is not None and read_timeout <= 0:
             raise ValueError("read_timeout should be >= 0")
         self._read_timeout = read_timeout
@@ -893,8 +891,8 @@ class Connection(object):
                     if DEBUG: print('connected using unix_socket')
                 else:
                     kwargs = {}
-                    if self.bind is not None:
-                        kwargs['source_address'] = (self.bind, 0)
+                    if self.bind_address is not None:
+                        kwargs['source_address'] = (self.bind_address, 0)
                     while True:
                         try:
                             sock = socket.create_connection(


### PR DESCRIPTION
When connecting via TCP/IP, provide a means to the client to bind the
socket to be created to a specific source address.  This is useful
when the client host has multiple network interfaces and a specific
one must be used for database traffic.

Add a new optional "bind" argument to class Connection, to specify the
interface from which to connect to the DB. Argument can be a hostname
or an IP address.