### PR TITLE
error of socket.create_connection (Python 3.5) if connect_timeout is set to 0

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -670,7 +670,7 @@ class Connection(object):
         self.client_flag = client_flag
 
         self.cursorclass = cursorclass
-        self.connect_timeout = connect_timeout
+        self.connect_timeout = connect_timeout or None
 
         self._result = None
         self._affected_rows = 0


### PR DESCRIPTION
### ERROR
I was change my project using torndb from Python2 to Python3.5, and i found that when i use PyMySQL instead of MySQLdb, error was raised when client tried to connect to mysql.
```
Traceback (most recent call last):
  File "/home/cm/work/bili_xcode_cluster_api/env/lib/python3.5/site-packages/pymysql/connections.py", line 890, in connect
    (self.host, self.port), self.connect_timeout)
  File "/usr/lib/python3.5/socket.py", line 711, in create_connection
    raise err
  File "/usr/lib/python3.5/socket.py", line 702, in create_connection
    sock.connect(sa)
BlockingIOError: [Errno 115] Operation now in progress
```
And i found that it all caused by socket.create_connection, socket is setnonblocking if timeout is 0, and then `BlockingIOError: [Errno 115] Operation now in progress` will be raised, so i suggest to set timeout after 
![image](https://cloud.githubusercontent.com/assets/22073484/21305935/475ca158-c609-11e6-9d4f-7ef640309863.png)

### CHANGE
 Set timeout after socket connection being created in case of 115 error raised if connect_timeout is 0