### PR TITLE
Allow semicolon at the end of bulk insert query

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -14,7 +14,7 @@ from . import err
 RE_INSERT_VALUES = re.compile(
     r"\s*((?:INSERT|REPLACE)\s.+\sVALUES?\s+)" +
     r"(\(\s*(?:%s|%\(.+\)s)\s*(?:,\s*(?:%s|%\(.+\)s)\s*)*\))" +
-    r"(\s*(?:ON DUPLICATE.*)?)(;\s*)\Z",
+    r"(\s*(?:ON DUPLICATE.*)?)(;*\s*)\Z",
     re.IGNORECASE | re.DOTALL)
 
 

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -14,7 +14,7 @@ from . import err
 RE_INSERT_VALUES = re.compile(
     r"\s*((?:INSERT|REPLACE)\s.+\sVALUES?\s+)" +
     r"(\(\s*(?:%s|%\(.+\)s)\s*(?:,\s*(?:%s|%\(.+\)s)\s*)*\))" +
-    r"(\s*(?:ON DUPLICATE.*)?)\Z",
+    r"(\s*(?:ON DUPLICATE.*)?)(;\s*)\Z",
     re.IGNORECASE | re.DOTALL)
 
 

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -14,7 +14,7 @@ from . import err
 RE_INSERT_VALUES = re.compile(
     r"\s*((?:INSERT|REPLACE)\s.+\sVALUES?\s+)" +
     r"(\(\s*(?:%s|%\(.+\)s)\s*(?:,\s*(?:%s|%\(.+\)s)\s*)*\))" +
-    r"(\s*(?:ON DUPLICATE.*)?)(;*\s*)\Z",
+    r"(\s*(?:ON DUPLICATE.*)?);?\s*\Z",
     re.IGNORECASE | re.DOTALL)
 
 


### PR DESCRIPTION
When running bulk insert with executemany(), the regex should allow semicolon at the end of the query.