### PR TITLE
Prevent a close() on a NoneType

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -735,11 +735,7 @@ class Connection(object):
         except Exception:
             pass
         finally:
-            sock = self._sock
-            self._sock = None
-            self._rfile = None
-            if hasattr(sock, 'close'):
-                sock.close()
+            self._force_close()
 
     @property
     def open(self):

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -738,7 +738,8 @@ class Connection(object):
             sock = self._sock
             self._sock = None
             self._rfile = None
-            sock.close()
+            if hasattr(sock, 'close'):
+                sock.close()
 
     @property
     def open(self):


### PR DESCRIPTION
If _write_bytes fails, _force_close is called which sets self._sock = None. Since we can't call close() on a NoneType, we first check if the attribute is present at all.