### PR TITLE
Add encrypted login path file support.

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -536,7 +536,7 @@ class Connection(object):
                  autocommit=False, db=None, passwd=None, local_infile=False,
                  max_allowed_packet=16*1024*1024, defer_connect=False,
                  auth_plugin_map={}, read_timeout=None, write_timeout=None,
-                 bind_address=None):
+                 bind_address=None, login_path=None):
         """
         Establish a connection to the MySQL database. Accepts several
         arguments:
@@ -583,6 +583,8 @@ class Connection(object):
             The class needs an authenticate method taking an authentication packet as
             an argument.  For the dialog plugin, a prompt(echo, prompt) method can be used
             (if no authenticate method) for returning a string from the user. (experimental)
+        login_path: A login path group to read from the encrypted login path
+            file. Or, `True` to read the default "client" group.
         db: Alias for database. (for compatibility to MySQLdb)
         passwd: Alias for password. (for compatibility to MySQLdb)
         """
@@ -604,6 +606,28 @@ class Connection(object):
         if self._local_infile:
             client_flag |= CLIENT.LOCAL_FILES
 
+        if login_path:
+            if login_path is True:
+                login_path = 'client'
+
+            from .login_path import open_login_path_file
+            login_path_file = open_login_path_file()
+
+            if (login_path_file is None):
+                raise RuntimeError('Error reading login path file.')
+
+            lp_cfg = Parser()
+            if PY2:
+                lp_cfg.readfp(login_path_file)
+            else:
+                lp_cfg.read_file(login_path_file)
+
+            user = lp_cfg.get(login_path, 'user', user)
+            password = lp_cfg.get(login_path, 'password', password)
+            host = lp_cfg.get(login_path, 'host', host)
+            unix_socket = lp_cfg.get(login_path, 'socket', unix_socket)
+            port = int(lp_cfg.get(login_path, 'port', port))
+
         if read_default_group and not read_default_file:
             if sys.platform.startswith("win"):
                 read_default_file = "c:\\my.ini"
@@ -617,27 +641,19 @@ class Connection(object):
             cfg = Parser()
             cfg.read(os.path.expanduser(read_default_file))
 
-            def _config(key, arg):
-                if arg:
-                    return arg
-                try:
-                    return cfg.get(read_default_group, key)
-                except Exception:
-                    return arg
-
-            user = _config("user", user)
-            password = _config("password", password)
-            host = _config("host", host)
-            database = _config("database", database)
-            unix_socket = _config("socket", unix_socket)
-            port = int(_config("port", port))
-            bind_address = _config("bind-address", bind_address)
-            charset = _config("default-character-set", charset)
+            user = cfg.get(read_default_group, "user", user)
+            password = cfg.get(read_default_group, "password", password)
+            host = cfg.get(read_default_group, "host", host)
+            database = cfg.get(read_default_group, "database", database)
+            unix_socket = cfg.get(read_default_group, "socket", unix_socket)
+            port = int(cfg.get(read_default_group, "port", port))
+            bind_address = cfg.get(read_default_group, "bind-address", bind_address)
+            charset = cfg.get(read_default_group, "default-character-set", charset)
             if not ssl:
                 ssl = {}
             if isinstance(ssl, dict):
                 for key in ["ca", "capath", "cert", "key", "cipher"]:
-                    value = _config("ssl-" + key, ssl.get(key))
+                    value = cfg.get(read_default_group, "ssl-" + key, ssl.get(key))
                     if value:
                         ssl[key] = value
 
@@ -806,7 +822,7 @@ class Connection(object):
 
     def escape(self, obj, mapping=None):
         """Escape whatever value you pass to it.
-        
+
         Non-standard, for internal use; do not use this in your applications.
         """
         if isinstance(obj, str_type):
@@ -815,7 +831,7 @@ class Connection(object):
 
     def literal(self, obj):
         """Alias for escape()
-        
+
         Non-standard, for internal use; do not use this in your applications.
         """
         return self.escape(obj, self.encoders)
@@ -1491,7 +1507,7 @@ class MySQLResult(object):
                     # This behavior is different from TEXT / BLOB.
                     # We should decode result by connection encoding regardless charsetnr.
                     # See https://github.com/PyMySQL/PyMySQL/issues/488
-                    encoding = conn_encoding  # SELECT CAST(... AS JSON) 
+                    encoding = conn_encoding  # SELECT CAST(... AS JSON)
                 elif field_type in TEXT_TYPES:
                     if field.charsetnr == 63:  # binary
                         # TEXTs with charset=binary means BINARY types.

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -613,7 +613,7 @@ class Connection(object):
             from .login_path import open_login_path_file
             login_path_file = open_login_path_file()
 
-            if (login_path_file is None):
+            if login_path_file is None:
                 raise RuntimeError('Error reading login path file.')
 
             lp_cfg = Parser()

--- a/pymysql/login_path.py
+++ b/pymysql/login_path.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""Funtions that read and decrypt MySQL's login path file."""
+
+from io import BytesIO, TextIOWrapper
+import os
+import struct
+
+try:
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    from cryptography.hazmat.backends import default_backend
+except ImportError:
+    raise ImportError('You must install the package "cryptography" in order '
+                      'to read the login path file.')
+
+# Buffer at the beginning of the login path file.
+UNUSED_BUFFER_LENGTH = 4
+
+# The key stored in the file.
+LOGIN_KEY_LENGTH = 20
+
+# The entire login key header.
+LOGIN_KEY_HEADER_LENGTH = UNUSED_BUFFER_LENGTH + LOGIN_KEY_LENGTH
+
+# Number of bytes used to store the length of ciphertext.
+CIPHER_STORE_LENGTH = 4
+
+
+def open_login_path_file():
+    """Open a decrypted version of the login path file."""
+    path = get_login_path_file()
+    try:
+        with open(path, 'rb') as fp:
+            key = read_key(fp)
+            cipher = get_aes_cipher(key)
+            plaintext = decrypt_file(fp, cipher.decryptor())
+    except (OSError, IOError):
+        return None
+
+    if not isinstance(plaintext, BytesIO):
+        return None
+
+    return TextIOWrapper(plaintext)
+
+
+def get_login_path_file():
+    """Return the login path file's path or None if it doesn't exist."""
+    app_data = os.getenv('APPDATA')
+    default_dir = os.path.join(app_data, 'MySQL') if app_data else '~'
+    file_path = os.path.join(default_dir, '.mylogin.cnf')
+
+    return os.getenv('MYSQL_TEST_LOGIN_FILE',
+                     os.path.expanduser(file_path))
+
+
+def read_key(fp):
+    """Read the key from the login path file header."""
+    # Move past the unused buffer.
+    _buffer = fp.read(UNUSED_BUFFER_LENGTH)
+
+    if not _buffer or len(_buffer) != UNUSED_BUFFER_LENGTH:
+        # Login path file is blank or incomplete.
+        return None
+
+    return create_key(fp.read(LOGIN_KEY_LENGTH))
+
+
+def create_key(key):
+    """Create the AES key from the login path file header."""
+    rkey = [0] * 16
+    for i in range(len(key)):
+        try:
+            rkey[i % len(rkey)] ^= ord(key[i:i + 1])
+        except TypeError:
+            # ord() was unable to get the value of the byte.
+            return None
+    return struct.pack('16B', *rkey)
+
+
+def get_aes_cipher(key):
+    """Get the AES cipher object."""
+    return Cipher(algorithms.AES(key), modes.ECB(),
+                  backend=default_backend())
+
+
+def decrypt_file(f, decryptor):
+    """Decrypt a file *f* using *decryptor*."""
+    plaintext = BytesIO()
+
+    f.seek(LOGIN_KEY_HEADER_LENGTH)
+    while True:
+        # Read the length of the line.
+        length_buffer = f.read(CIPHER_STORE_LENGTH)
+        if len(length_buffer) < CIPHER_STORE_LENGTH:
+            break
+        line_length, = struct.unpack('<i', length_buffer)
+        line = read_line(f, line_length, decryptor)
+        plaintext.write(line)
+
+    plaintext.seek(0)
+    return plaintext
+
+
+def read_line(f, length, decryptor):
+    """Read a line of length *length* from file *f* using *decryptor*."""
+    line = f.read(length)
+    return remove_pad(decryptor.update(line))
+
+
+def remove_pad(line):
+    """Remove the pad from the *line*."""
+    try:
+        pad_length = ord(line[-1:])
+    except TypeError:
+        # ord() was unable to get the value of the byte.
+        return None
+
+    if pad_length > len(line):
+        # Pad length should be less than or equal to the length of the
+        # plaintext.
+        return None
+
+    return line[:-pad_length]

--- a/pymysql/optionfile.py
+++ b/pymysql/optionfile.py
@@ -15,6 +15,13 @@ class Parser(configparser.RawConfigParser):
                 return value[1:-1]
         return value
 
-    def get(self, section, option):
-        value = configparser.RawConfigParser.get(self, section, option)
-        return self.__remove_quotes(value)
+    def get(self, section, option, var):
+        """Get *option* from *section* if *var* is not supplied."""
+        if var:
+            return var
+        try:
+            value = configparser.RawConfigParser.get(self, section, option)
+        except configparser.Error:
+            return var
+        else:
+            return self.__remove_quotes(value)

--- a/pymysql/optionfile.py
+++ b/pymysql/optionfile.py
@@ -15,7 +15,7 @@ class Parser(configparser.RawConfigParser):
                 return value[1:-1]
         return value
 
-    def get(self, section, option, var):
+    def get(self, section, option, var=None):
         """Get *option* from *section* if *var* is not supplied."""
         if var:
             return var

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setup(
     description='Pure Python MySQL Driver',
     license="MIT",
     packages=find_packages(),
+    extras_require={
+        'loginpath':  ["cryptography>=1.0.0"]
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python :: 2',


### PR DESCRIPTION
This addresses #362.

This pull request adds an optional dependency, the [cryptography package](https://github.com/pyca/cryptography), which supports Python 2.6-2.7, Python 3.3+, and PyPy 2.6+. This package is used to decrypt the encrypted login path file so that `host`, `user`, `password`, `socket`, and `port` can be read from a login path group.

If users want to install PyMySQL with login path support, they simply run `pip install pymysql[loginpath]`, which will install both PyMySQL and cryptography.

The `Connection()` keyword arguments for `host`, `user`, `password`, `unix_socket`, and `port` continue to have the highest precedence, so they outweigh values in the login path file.

The login path file is expected to be at:
- `%APPDATA%\MySQL\.mylogin.cnf` (Windows)
- `~/.mylogin.cnf` (non-Windows)

Or, the `MYSQL_TEST_LOGIN_FILE` environment variable is read for an alternative login path file location. This is per the [MySQL docs](https://dev.mysql.com/doc/refman/5.7/en/option-files.html).

If `Connection()` is called with the `login_path` argument, but cryptography is not installed, then an `ImportError` is raised with an appropriate message.

If the `login_path` argument is passed to `Connection()`, but the login path file is unable to be opened, then a `RuntimeError` is raised.

## Installation
Either of these will install PyMySQL with login path file support:
- `pip install pymysql[loginpath]`
- `pip install pymysql cryptography`

## Examples

```python
from pymysql.connections import Connection

# Login path file is not opened and cryptography is not imported.
Connection(user=user, host=host, password=password)

# Login path file is opened and `client` group is read.
Connection(login_path=True)

# Login path file is opened and `qa1` group is read.
Connection(login_path='qa1')

# Login path file is opened, `client` group is read, but `host` is overriden.
Connection(host='db.domain.com', login_path='client')
```