### PR TITLE
Fix connection procedure auth-switch wrong plugin auth method.

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -1186,7 +1186,7 @@ class Connection(object):
             data = _scramble(self.password.encode('latin1'), auth_packet.read_all())
         elif plugin_name == b"mysql_old_password":
             # https://dev.mysql.com/doc/internals/en/old-password-authentication.html
-            data = _scramble_323(self.password.encode('latin1'), auth_packet.read_all())
+            data = _scramble_323(self.password.encode('latin1'), auth_packet.read_all()) + b'\0'
         elif plugin_name == b"mysql_clear_password":
             # https://dev.mysql.com/doc/internals/en/clear-text-authentication.html
             data = self.password.encode('latin1') + b'\0'

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -1183,10 +1183,10 @@ class Connection(object):
             handler = None
         if plugin_name == b"mysql_native_password":
             # https://dev.mysql.com/doc/internals/en/secure-password-authentication.html#packet-Authentication::Native41
-            data = _scramble(self.password.encode('latin1'), auth_packet.read_all()) + b'\0'
+            data = _scramble(self.password.encode('latin1'), auth_packet.read_all())
         elif plugin_name == b"mysql_old_password":
             # https://dev.mysql.com/doc/internals/en/old-password-authentication.html
-            data = _scramble_323(self.password.encode('latin1'), auth_packet.read_all()) + b'\0'
+            data = _scramble_323(self.password.encode('latin1'), auth_packet.read_all())
         elif plugin_name == b"mysql_clear_password":
             # https://dev.mysql.com/doc/internals/en/clear-text-authentication.html
             data = self.password.encode('latin1') + b'\0'


### PR DESCRIPTION
For AuthSwitch feature, mysql_native_password and mysql_old_password
should reply only 8-byte or 20-byte scrambled password without '\0'. Use '\0' will let MySQL server reply Error Code 1043 which means Bad HandShake.
Please see the https://web.archive.org/web/20170405005641/https://dev.mysql.com/doc/internals/en/secure-password-authentication.html . 
Also see connections.py line 11130, which also responsed with no '\0'.