### PR TITLE
Fix handle AuthSwitch packet bug.

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -132,6 +132,8 @@ def dump_packet(data): # pragma: no cover
     print()
 
 
+SCRAMBLE_LENGTH = 20
+
 def _scramble(password, message):
     if not password:
         return b''
@@ -139,7 +141,7 @@ def _scramble(password, message):
     stage1 = sha_new(password).digest()
     stage2 = sha_new(stage1).digest()
     s = sha_new()
-    s.update(message)
+    s.update(message[:SCRAMBLE_LENGTH]) 
     s.update(stage2)
     result = s.digest()
     return _my_crypt(result, stage1)


### PR DESCRIPTION
MySQL documents annouce the AuthSwitch packet is contains with two
component `auth_plugin_name` and `auth_data`, which `auth_data` is
a string[EOF] string. But in fact it will return a string[NUL] string
or can also say the string[EOF] is consist of a 20bytes string and a '\0'
byte. Now we just follow the document which use those 21bytes as salt
and that is not correct.