### PR TITLE
connection option 'read_default_file'  allow no value

### DIFF
--- a/pymysql/optionfile.py
+++ b/pymysql/optionfile.py
@@ -7,6 +7,9 @@ else:
 
 
 class Parser(configparser.RawConfigParser):
+    def __init__(self, **kwargs):
+        kwargs['allow_no_value'] = True
+        configparser.RawConfigParser.__init__(self, **kwargs)
 
     def __remove_quotes(self, value):
         quotes = ["'", "\""]

--- a/pymysql/tests/test_optionfile.py
+++ b/pymysql/tests/test_optionfile.py
@@ -16,6 +16,7 @@ _cfg_file = (r"""
 string = foo
 quoted = "bar"
 single_quoted = 'foobar'
+skip-slave-start
 """)
 
 


### PR DESCRIPTION
solve current config parser not allow no value
```
ParsingError: File contains parsing errors: /etc/mysql/my.cnf
	[line 51]: 'skip-name-resolve\n'
	[line 61]: 'skip-external-locking\n'
	[line 79]: 'log-bin\n'
	[line 125]: 'innodb_file_per_table\n'
````