### PR TITLE
allow no whitespaces between `VALUES` and `(` when do bulk insert/replace

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -12,7 +12,7 @@ from . import err
 #: executemany only suports simple bulk insert.
 #: You can use it to load large dataset.
 RE_INSERT_VALUES = re.compile(
-    r"\s*((?:INSERT|REPLACE)\s.+\sVALUES?\s*)" +
+    r"\s*((?:INSERT|REPLACE)\b.+\bVALUES?\s*)" +
     r"(\(\s*(?:%s|%\(.+\)s)\s*(?:,\s*(?:%s|%\(.+\)s)\s*)*\))" +
     r"(\s*(?:ON DUPLICATE.*)?);?\s*\Z",
     re.IGNORECASE | re.DOTALL)

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -12,7 +12,7 @@ from . import err
 #: executemany only suports simple bulk insert.
 #: You can use it to load large dataset.
 RE_INSERT_VALUES = re.compile(
-    r"\s*((?:INSERT|REPLACE)\s.+\sVALUES?\s+)" +
+    r"\s*((?:INSERT|REPLACE)\s.+\sVALUES?\s*)" +
     r"(\(\s*(?:%s|%\(.+\)s)\s*(?:,\s*(?:%s|%\(.+\)s)\s*)*\))" +
     r"(\s*(?:ON DUPLICATE.*)?);?\s*\Z",
     re.IGNORECASE | re.DOTALL)

--- a/pymysql/tests/test_cursor.py
+++ b/pymysql/tests/test_cursor.py
@@ -79,6 +79,10 @@ class CursorTest(base.PyMySQLTestCase):
         self.assertIsNotNone(m, 'error parse %(id_name)s')
         self.assertEqual(m.group(3), ' ON duplicate update', 'group 3 not ON duplicate update, bug in RE_INSERT_VALUES?')
 
+        # https://github.com/PyMySQL/PyMySQL/pull/597
+        m = pymysql.cursors.RE_INSERT_VALUES.match("INSERT INTO bloup(foo, bar)VALUES(%s, %s)")
+        assert m is not None
+
         # cursor._executed must bee "insert into test (data) values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9)"
         # list args
         data = range(10)


### PR DESCRIPTION
the [regular expression](../blob/master/pymysql/cursors.py#L15) used to check whether bulk insert/replace is possible is as follows:
```python
RE_INSERT_VALUES = re.compile(
    r"\s*((?:INSERT|REPLACE)\s.+\sVALUES?\s+)" +
    r"(\(\s*(?:%s|%\(.+\)s)\s*(?:,\s*(?:%s|%\(.+\)s)\s*)*\))" +
    r"(\s*(?:ON DUPLICATE.*)?);?\s*\Z",
    re.IGNORECASE | re.DOTALL)
```
notice the last `\s+` in the first part of the regular expression requires whitespaces between `VALUES` and left-parenthesis, which means queries like `insert into user values(%s, %s)` would not be considered bulk-insertable. although the demo sql query in the comment of `executemany` has a space between `VALUES` and `(`, i do think this restriction could be relaxed.

This gotcha is so trivial and would cost some time to realize. It actually costed me some time to find out why the performance of a relatively simple program dropped by more than 6 times after switching from MySQLdb to PyMySQL.

The fix is quite simple, just replace the `\s+` with `\s*` in the first part.

**NOTE:** ported from https://github.com/PyMySQL/mysqlclient-python/commit/354dcb59e286b0db3b108c92760d3ec135a8bc23