### PR TITLE
remove shebangs and unusable main code

### DIFF
--- a/pymysql/tests/thirdparty/test_MySQLdb/capabilities.py
+++ b/pymysql/tests/thirdparty/test_MySQLdb/capabilities.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python -O
 """ Script to test database capabilities and the DB-API interface
     for functionality and memory leaks.
 

--- a/pymysql/tests/thirdparty/test_MySQLdb/dbapi20.py
+++ b/pymysql/tests/thirdparty/test_MySQLdb/dbapi20.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 ''' Python DB API 2.0 driver compliance unit test suite.
 
     This software is Public Domain and may be used without restrictions.

--- a/pymysql/tests/thirdparty/test_MySQLdb/test_MySQLdb_capabilities.py
+++ b/pymysql/tests/thirdparty/test_MySQLdb/test_MySQLdb_capabilities.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from . import capabilities
 try:
     import unittest2 as unittest
@@ -99,11 +98,3 @@ class test_MySQLdb(capabilities.DatabaseTest):
 
     def test_literal_string(self):
         self.assertTrue("'foo'" == self.connection.literal("foo"))
-
-
-if __name__ == '__main__':
-    if test_MySQLdb.leak_test:
-        import gc
-        gc.enable()
-        gc.set_debug(gc.DEBUG_LEAK)
-    unittest.main()

--- a/pymysql/tests/thirdparty/test_MySQLdb/test_MySQLdb_dbapi20.py
+++ b/pymysql/tests/thirdparty/test_MySQLdb/test_MySQLdb_dbapi20.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from . import dbapi20
 import pymysql
 from pymysql.tests import base
@@ -204,7 +203,3 @@ class test_MySQLdb(dbapi20.DatabaseAPI20Test):
 
         finally:
             con.close()
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
remove shebangs and unusable main code

these python scripts don't contain "main code" (to be executed stand only), I don't see why a shebang (#!) should be added.

the removed "main code" is unusable (as far as I know), when executing it gives the following error: `ImportError: cannot import name 'capabilities'`

The shebang in these scripts are against the packing guidelines for Fedora and requires this patchwork:
http://pkgs.fedoraproject.org/cgit/rpms/python-PyMySQL.git/tree/python-PyMySQL.spec#n64