### PR TITLE
add string cast for database, user and password to correctly manage

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -652,9 +652,9 @@ class Connection(object):
 
         self.host = host or "localhost"
         self.port = port or 3306
-        self.user = user or DEFAULT_USER
-        self.password = password or ""
-        self.db = database
+        self.user = str(user) or DEFAULT_USER
+        self.password = str(password) or ""
+        self.db = str(database)
         self.unix_socket = unix_socket
         self.bind_address = bind_address
         if not (0 < connect_timeout <= 31536000):


### PR DESCRIPTION
A pg_chameleon user noticed that using numerical passwords can cause issues because the password could be wrongly interpreted as an integer. Here the details of the problem https://github.com/the4thdoctor/pg_chameleon/issues/31

I'm fixing the issue on my side. This PR should fix the problem on the source :)

Thanks