### PR TITLE
Bump MySQLdb version from 1.2.6 to 1.3.12

### DIFF
--- a/pymysql/__init__.py
+++ b/pymysql/__init__.py
@@ -104,7 +104,7 @@ def get_client_info():  # for MySQLdb compatibility
 connect = Connection = Connect
 
 # we include a doctored version_info here for MySQLdb compatibility
-version_info = (1,2,6,"final",0)
+version_info = (1, 3, 12, "final", 0)
 
 NULL = "NULL"
 


### PR DESCRIPTION
Fix #610 by bumping MySQLdb version to 1.3.12
tested with [django_backend_test](https://github.com/eavictor/django_backend_test), skip BinaryField test (issue 549).

test result (paste here again):
```
EAVICTOR-MBPR:django_backend_test eavictor$ python3 manage.py test
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.......................................
----------------------------------------------------------------------
Ran 39 tests in 8.070s

OK
Destroying test database for alias 'default'...
EAVICTOR-MBPR:django_backend_test eavictor$ 
```