### PR TITLE
add AttrDictCursor

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -396,6 +396,24 @@ class DictCursor(DictCursorMixin, Cursor):
     """A cursor which returns results as a dictionary"""
 
 
+class AttrDict(dict):
+    """A dictionary that can get/set attribute by dot"""
+
+    def __getattr__(self, name):
+        return self[name]
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+
+class AttrDictCursor(DictCursor):
+    """
+    A cursor which returns results as a dictionary,
+    and the dictionary can get/set attribute by dot
+    """
+    dict_type = AttrDict
+
+
 class SSCursor(Cursor):
     """
     Unbuffered Cursor, mainly useful for queries that return a lot of data,

--- a/pymysql/tests/test_cursor.py
+++ b/pymysql/tests/test_cursor.py
@@ -106,3 +106,29 @@ class CursorTest(base.PyMySQLTestCase):
             self.assertTrue(cursor._executed.endswith(b"(3, 4),(5, 6)"), "executemany with %% not in one query")
         finally:
             cursor.execute("DROP TABLE IF EXISTS percent_test")
+
+    def test_fetch_result_type(self):
+        conn = self.test_connection
+        cursor = conn.cursor(pymysql.cursors.DictCursor)
+        cursor.execute("select 1 as t1")
+        self.assertEqual(cursor.fetchone(), {"t1": 1})
+
+        cursor.execute(
+            "insert into test (data) values "
+            "('row1'), ('row2'), ('row3'), ('row4'), ('row5')")
+        cursor.execute("select * from test")
+        self.assertIsInstance(cursor.fetchall()[0], dict)
+        cursor.close()
+
+        cursor = conn.cursor(pymysql.cursors.AttrDictCursor)
+        cursor.execute("select 1 as t1")
+        row = cursor.fetchone()
+        self.assertEqual(row, {"t1": 1})
+        self.assertEqual(row.t1, 1)
+
+        cursor.execute(
+            "insert into test (data) values "
+            "('row1'), ('row2'), ('row3'), ('row4'), ('row5')")
+        cursor.execute("select * from test")
+        self.assertIsInstance(cursor.fetchall()[0], dict)
+        cursor.close()


### PR DESCRIPTION
Let results allow attribute-style access, and I think it can be a bit user-friendly.
data = {"row1": "the first row", "row2": "foo"}
data["row1"]   VS  data.row1