### PR TITLE
Reduce callproc roundtrip time

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -259,9 +259,10 @@ class Cursor(object):
         disconnected.
         """
         conn = self._get_db()
-        for index, arg in enumerate(args):
-            q = "SET @_%s_%d=%s" % (procname, index, conn.escape(arg))
-            self._query(q)
+        if args:
+            argFmt = '@_{0}_%d=%s'.format(procname)
+            self._query('SET %s' % ','.join(argFmt % (index, conn.escape(arg))
+                                            for index, arg in enumerate(args)))
             self.nextset()
 
         q = "CALL %s(%s)" % (procname,

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -260,8 +260,8 @@ class Cursor(object):
         """
         conn = self._get_db()
         if args:
-            argFmt = '@_{0}_%d=%s'.format(procname)
-            self._query('SET %s' % ','.join(argFmt % (index, conn.escape(arg))
+            fmt = '@_{0}_%d=%s'.format(procname)
+            self._query('SET %s' % ','.join(fmt % (index, conn.escape(arg))
                                             for index, arg in enumerate(args)))
             self.nextset()
 


### PR DESCRIPTION
Rather than making an individual `SET` query for each and every parameter specified for a `callproc` call, use one single call instead, saving round-trip time (if one has more than one parameter). This can be significant if one is making many repeated `callproc` calls which have multiple arguments.

Then only downside I can think of is that if one or more arguments are quite large, combining them all could hit the [max_allowed_packet](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_allowed_packet) limit. However, if it is only e.g. one large argument this will make next to no difference and the user should have an increased `max_allowed_packet` value in anticipation of e.g. larger blobs already.

**Edit**: As far as I can tell the CI test failures are nothing to do with my change, producing errors about invalid syntax for unrelated queries. `test_callproc` in fact passes.