### PR TITLE
Auto ping

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -576,7 +576,7 @@ class Connection(object):
                  autocommit=False, db=None, passwd=None, local_infile=False,
                  max_allowed_packet=16*1024*1024, defer_connect=False,
                  auth_plugin_map={}, read_timeout=None, write_timeout=None,
-                 bind_address=None, binary_prefix=False):
+                 bind_address=None, binary_prefix=False, auto_ping=False):
         if no_delay is not None:
             warnings.warn("no_delay option is deprecated", DeprecationWarning)
 
@@ -681,6 +681,8 @@ class Connection(object):
 
         #: specified autocommit mode. None means use server default.
         self.autocommit_mode = autocommit
+
+        self.auto_ping = auto_ping
 
         if conv is None:
             conv = converters.conversions

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -851,6 +851,9 @@ class Connection(object):
 
     # The following methods are INTERNAL USE ONLY (called from Cursor)
     def query(self, sql, unbuffered=False):
+        if self.auto_ping:
+            self.ping()
+
         # if DEBUG:
         #     print("DEBUG: sending query:", sql)
         if isinstance(sql, text_type) and not (JYTHON or IRONPYTHON):
@@ -858,6 +861,7 @@ class Connection(object):
                 sql = sql.encode(self.encoding)
             else:
                 sql = sql.encode(self.encoding, 'surrogateescape')
+
         self._execute_command(COMMAND.COM_QUERY, sql)
         self._affected_rows = self._read_query_result(unbuffered=unbuffered)
         return self._affected_rows

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -68,8 +68,6 @@ class Cursor(object):
     def _get_db(self):
         if not self.connection:
             raise err.ProgrammingError("Cursor closed")
-        if self.connection.auto_ping:
-            self.connection.ping()
         return self.connection
 
     def _check_executed(self):

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -68,6 +68,8 @@ class Cursor(object):
     def _get_db(self):
         if not self.connection:
             raise err.ProgrammingError("Cursor closed")
+        if self.connection.auto_ping:
+            self.connection.ping()
         return self.connection
 
     def _check_executed(self):


### PR DESCRIPTION
This is to avoid connection has been idle for long time and mysql server has closed it.

When try to execute query on this connection again, `err.InterfaceError("(0, '')")` or `pymysql.err.OperationalError: (2013, 'Lost connection to MySQL server during query')` raised.

After set `auto_ping` param on `Connection` construct function, every time connection do query, it will `ping()` first.