### PR TITLE
Improve documentation with errors and links

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -24,6 +24,9 @@ class Cursor(object):
 
     Do not create an instance of a Cursor yourself. Call
     connections.Connection.cursor().
+
+    See `Cursor <https://www.python.org/dev/peps/pep-0249/#cursor-objects>`_ in
+    the specification.
     """
 
     #: Max statement size which :meth:`executemany` generates.


### PR DESCRIPTION
I added several links to the PEP 249 documentation. I also documented
the various exceptions that can be raised and, clarified the meaning
of some parameters.

Overall, readers will be able to cross-reference methods with the
specification, and will see implementation-specific info. This will
make it clear that this library implements the full specification,
which is important because there is almost no direct documentation
of this library.

I've confirmed that the docs build correctly using the makefile in `docs/`.

Let me know if I missed anything, or if there are any style issues.