### PR TITLE
Make it possible to actually unblock a blocking receive

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -1065,6 +1065,8 @@ class Connection(object):
                 break
             except (IOError, OSError) as e:
                 if e.errno == errno.EINTR:
+                    if self._closed:
+                        return
                     continue
                 self._force_close()
                 raise err.OperationalError(

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -749,6 +749,7 @@ class Connection(object):
         """Close connection without QUIT message"""
         if self._sock:
             try:
+                self._sock.shutdown(socket.SHUT_RDWR)
                 self._sock.close()
             except:
                 pass

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -752,6 +752,8 @@ class Connection(object):
                 self._sock.close()
             except:
                 pass
+        if self._rfile:
+            self._rfile.close()
         self._sock = None
         self._rfile = None
 


### PR DESCRIPTION
Packages such as https://github.com/noplay/python-mysql-replication call `_read_packet`, which blocks forever. Evening closing the underlying connection with `.close()` causes nothing to happen.

Calling `socket.shutdown` on the socket actually causes the blocking read to get unstuck. On top of that, if a read returns `EINTR`, you're not supposed to just blindly continue. You're supposed to check if you might need to unblock. Even though this never happens because the socket is in blocking mode.