### PR TITLE
testfix: MySQL-5.1, test_context requires transactional engine

### DIFF
--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -443,7 +443,7 @@ class TestConnection(base.PyMySQLTestCase):
         with self.assertRaises(ValueError):
             c = self.connect()
             with c as cur:
-                cur.execute('create table test ( a int )')
+                cur.execute('create table test ( a int ) ENGINE=InnoDB')
                 c.begin()
                 cur.execute('insert into test values ((1))')
                 raise ValueError('pseudo abort')


### PR DESCRIPTION
This was discovered testing against MySQL-5.1 because the default engine is MyISAM. The test is explicitly testing transactional operations so force Engine=Innodb.