### PR TITLE
testfix: MySQL-5.1 GEOM

### DIFF
--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -465,7 +465,8 @@ class TestGitHubIssues(base.PyMySQLTestCase):
         else:
             cur.execute(query)
         row = cur.fetchone()
-        self.assertEqual(row, ("LINESTRING(1.1 1.1,2.2 2.2)", ))
+        self.assertIn(row, ( ("LINESTRING(1.1 1.1,2.2 2.2)", ),
+                             (b"LINESTRING(1.1 1.1,2.2 2.2)", ) ))
 
         # select WKB
         query = "SELECT AsBinary(geom) FROM issue363"


### PR DESCRIPTION
It appears in MySQL-5.1, the GEOM results are binary rather than UTF8. Allow both answers in the test suite.

Found when testing MySQL-5.1 with Python-3.5.