### PR TITLE
SSCursor: failed to clear unused results on deletion

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -446,6 +446,8 @@ class SSCursor(Cursor):
         finally:
             self.connection = None
 
+    __del__ = close
+
     def _query(self, q):
         conn = self._get_db()
         self._last_executed = q


### PR DESCRIPTION
A cursor may contain unretrieved results. These should be consumed
before a new cursor is created on the same connection.

Tested on MySQL-5.1

error was:

```
======================================================================
ERROR: test_cleanup_rows_unbuffered (pymysql.tests.test_cursor.CursorTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "PyMySQL/pymysql/tests/test_cursor.py", line 37, in test_cleanup_rows_unbuffered
    c2.execute("select 1")
  File "PyMySQL/pymysql/cursors.py", line 172, in execute
    result = self._query(query)
  File "PyMySQL/pymysql/cursors.py", line 330, in _query
    conn.query(q)
  File "PyMySQL/pymysql/connections.py", line 890, in query
    self._execute_command(COMMAND.COM_QUERY, sql)
  File "PyMySQL/pymysql/connections.py", line 1126, in _execute_command
    warnings.warn("Previous unbuffered result was left incomplete")
UserWarning: Previous unbuffered result was left incomplete
```