### PR TITLE
test: issue3 MySQL-8.0 now returns NULL(None) for timestamp

### DIFF
--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -36,7 +36,7 @@ class TestOldIssues(base.PyMySQLTestCase):
             c.execute("select dt from issue3")
             self.assertEqual(None, c.fetchone()[0])
             c.execute("select ts from issue3")
-            self.assertTrue(isinstance(c.fetchone()[0], datetime.datetime))
+            self.assertIn(type(c.fetchone()[0]), (type(None), datetime.datetime), 'expected Python type None or datetime from SQL timestamp')
         finally:
             c.execute("drop table issue3")
 


### PR DESCRIPTION
... like all of the other temporal times.

Without fix fails like:
<pre>
  coverage run ./runtests.py pymysql.tests.test_issues.TestOldIssues.test_issue_3
test_issue_3 (pymysql.tests.test_issues.TestOldIssues)
undefined methods datetime_or_None, date_or_None ... FAIL

======================================================================
FAIL: test_issue_3 (pymysql.tests.test_issues.TestOldIssues)
undefined methods datetime_or_None, date_or_None
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dan/software_projects/PyMySQL/pymysql/tests/test_issues.py", line 39, in test_issue_3
    self.assertTrue(isinstance(c.fetchone()[0], datetime.datetime))
AssertionError: False is not true

----------------------------------------------------------------------
Ran 1 test in 1.071s

FAILED (failures=1)
No garbages!
</pre>