### PR TITLE
test_defer_connect: don't leak file descriptor

### DIFF
--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -471,6 +471,7 @@ class TestConnection(base.PyMySQLTestCase):
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock.connect(d['unix_socket'])
         except KeyError:
+            sock.close()
             sock = socket.create_connection(
                             (d.get('host', 'localhost'), d.get('port', 3306)))
         for k in ['unix_socket', 'host', 'port']:


### PR DESCRIPTION
This occured when no unix socket was present.

Prior to this commit got the output warning:
test_defer_connect (pymysql.tests.test_connection.TestConnection) ... Exception ignored in: <socket.socket fd=4, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0>
ResourceWarning: unclosed <socket.socket fd=4, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0>