### PR TITLE
Test mysql db capabilities / test_issue_364

### DIFF
--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -409,11 +409,11 @@ class TestGitHubIssues(base.PyMySQLTestCase):
 
     def test_issue_364(self):
         """ Test mixed unicode/binary arguments in executemany. """
-        conn = pymysql.connect(charset="utf8", **self.databases[0])
+        conn = pymysql.connect(charset="utf8mb4", **self.databases[0])
         self.safe_create_table(
             conn, "issue364",
             "create table issue364 (value_1 binary(3), value_2 varchar(3)) "
-            "engine=InnoDB default charset=utf8")
+            "engine=InnoDB default charset=utf8mb4")
 
         sql = "insert into issue364 (value_1, value_2) values (_binary %s, %s)"
         usql = u"insert into issue364 (value_1, value_2) values (_binary %s, %s)"

--- a/pymysql/tests/thirdparty/test_MySQLdb/capabilities.py
+++ b/pymysql/tests/thirdparty/test_MySQLdb/capabilities.py
@@ -17,8 +17,8 @@ class DatabaseTest(unittest.TestCase):
 
     db_module = None
     connect_args = ()
-    connect_kwargs = dict(use_unicode=True, charset="utf8", binary_prefix=True)
-    create_table_extra = "ENGINE=INNODB CHARACTER SET UTF8"
+    connect_kwargs = dict(use_unicode=True, charset="utf8mb4", binary_prefix=True)
+    create_table_extra = "ENGINE=INNODB CHARACTER SET UTF8MB4"
     rows = 10
     debug = False
 


### PR DESCRIPTION
Remove warnings about utf8 usage in MySQL-8.0