### PR TITLE
Travis: use docker for mysql-5.5, mysql-5.6,  mariadb-5.5, 10.0, 10.1, 10.2, 10.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,25 @@ language: python
 services:
   - docker
 
-python:
-  - "3.7-dev"
-  - "3.6"
-
 cache: pip
 
 matrix:
   include:
-    - addons:
-        mariadb: 5.5
+    - env:
+        - DB=mariadb:5.5
       python: "3.5"
-    - addons:
-        mariadb: 10.1
+    - env:
+        - DB=mariadb:10.0
+      python: "3.6"
+    - env:
+        - DB=mariadb:10.1
       python: "pypy"
-    - addons:
-        mariadb: 10.2
+    - env:
+        - DB=mariadb:10.2
       python: "2.7"
+    - env:
+        - DB=mariadb:10.3
+      python: "3.7-dev"
     - env:
         - DB=mysql:5.5
       python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 
 sudo: required
 language: python
+services:
+  - docker
+
 python:
   - "3.7-dev"
   - "3.6"
@@ -13,21 +16,21 @@ matrix:
     - addons:
         mariadb: 5.5
       python: "3.5"
-
     - addons:
         mariadb: 10.1
       python: "pypy"
-
     - addons:
         mariadb: 10.2
       python: "2.7"
-
     - env:
-        - DB=5.7
+        - DB=mysql:5.5
+      python: "3.5"
+    - env:
+        - DB=mysql:5.6
+      python: "3.6"
+    - env:
+        - DB=mysql:5.7
       python: "3.4"
-      services:
-        - docker
-
 
 # different py version from 5.6 and 5.7 as cache seems to be based on py version
 # http://dev.mysql.com/downloads/mysql/5.7.html has latest development release version

--- a/.travis/initializedb.sh
+++ b/.travis/initializedb.sh
@@ -9,8 +9,8 @@ if [ ! -z "${DB}" ]; then
     # disable existing database server in case of accidential connection
     sudo service mysql stop
 
-    docker pull mysql:${DB}
-    docker run -it --name=mysqld -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 3306:3306 mysql:${DB}
+    docker pull ${DB}
+    docker run -it --name=mysqld -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 3306:3306 ${DB}
     sleep 10
 
     while :


### PR DESCRIPTION
closes #494

By using DB names to include mariadb the Travis output is a lot clear as to what database is being tested:
https://travis-ci.org/grooverdan/PyMySQL/builds/372599838

The MariaDB docker versions are the latest upstream versions and ahead of those provided by Travis. 10.3 is a RC release now so including it.