### PR TITLE
Make `DBAPISet` support both sets and frozensets for equality checks

### DIFF
--- a/pymysql/__init__.py
+++ b/pymysql/__init__.py
@@ -44,13 +44,13 @@ paramstyle = "pyformat"
 class DBAPISet(frozenset):
 
     def __ne__(self, other):
-        if isinstance(other, set):
+        if isinstance(other, (set, frozenset)):
             return frozenset.__ne__(self, other)
         else:
             return other not in self
 
     def __eq__(self, other):
-        if isinstance(other, frozenset):
+        if isinstance(other, (set, frozenset)):
             return frozenset.__eq__(self, other)
         else:
             return other in self


### PR DESCRIPTION
The `__ne__` method was looking for sets and the `__eq__` method for frozensets.

Supporting both matches the behavior of `frozenset` itself.