### PR TITLE
Add mysql native password plugin name on init handshake phase

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -805,6 +805,7 @@ class Connection(object):
         plugin_name = None
 
         if self._auth_plugin_name in ('', 'mysql_native_password'):
+            plugin_name = b'mysql_native_password'
             authresp = _auth.scramble_native_password(self.password, self.salt)
         elif self._auth_plugin_name == 'caching_sha2_password':
             plugin_name = b'caching_sha2_password'

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -804,7 +804,10 @@ class Connection(object):
         authresp = b''
         plugin_name = None
 
-        if self._auth_plugin_name in ('', 'mysql_native_password'):
+        if self._auth_plugin_name == '':
+            plugin_name = b''
+            authresp = _auth.scramble_native_password(self.password, self.salt)
+        elif self._auth_plugin_name == 'mysql_native_password':
             plugin_name = b'mysql_native_password'
             authresp = _auth.scramble_native_password(self.password, self.salt)
         elif self._auth_plugin_name == 'caching_sha2_password':


### PR DESCRIPTION
Hi methane,
Sorry for disturb you. We are using PyMySQL and have a private proxy code to handle mysql login phase. Recently we faced a connection problem when PyMySQL upgrade to 0.9, and after diagnostic we found that it is a proxy internal bug that assume the auth plugin name should not be empty. We fixed the bug on our hands, but we still want to add the auth plugin name to PyMySQL code like protocol. 

In the MySQL protocol(https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::Handshake ), the client should figure out the auth_plugin_name
```
 if capabilities & CLIENT_PLUGIN_AUTH {
string[NUL]    auth plugin name
  }
```

We assume when the plugin is mysql_native_password, it should not be empty.

Thanks,
Shuode Li