### PR TITLE
Fix old-style password logins

### DIFF
--- a/pymysql/_auth.py
+++ b/pymysql/_auth.py
@@ -2,6 +2,7 @@
 Implements auth methods
 """
 from ._compat import text_type, PY2
+from .util import byte2int, int2byte
 from .constants import CLIENT
 from .err import OperationalError
 
@@ -12,6 +13,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from functools import partial
 import hashlib
 import struct
+import io
 
 
 DEBUG = False

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -894,7 +894,7 @@ class Connection(object):
         elif plugin_name == b"mysql_native_password":
             data = _auth.scramble_native_password(self.password, auth_packet.read_all())
         elif plugin_name == b"mysql_old_password":
-            data = _auth.scramble_old_password(self.password, auth_packet.read_all()) + b'\0'
+            data = _auth.scramble_old_password(self.password, self.salt) + b'\0'
         elif plugin_name == b"mysql_clear_password":
             # https://dev.mysql.com/doc/internals/en/clear-text-authentication.html
             data = self.password + b'\0'


### PR DESCRIPTION
During refactoring after May 7, 0.8.1 release support for old password logins was broken.  In _auth.py items were used without importing them, and in connections.py the function call to scramble_old_passwords was using the wrong arguments (needs self.salt)