### PR TITLE
Convert SET field to python set

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -17,7 +17,7 @@ import warnings
 from . import _auth
 
 from .charset import charset_by_name, charset_by_id
-from .constants import CLIENT, COMMAND, CR, FIELD_TYPE, SERVER_STATUS
+from .constants import CLIENT, COMMAND, CR, FIELD_TYPE, FLAG, SERVER_STATUS
 from . import converters
 from .cursors import Cursor
 from .optionfile import Parser
@@ -1232,11 +1232,15 @@ class MySQLResult(object):
                         encoding = None
                     else:
                         encoding = conn_encoding
+                    if field_type == FIELD_TYPE.STRING and field.flags & FLAG.SET:
+                        field_type = FIELD_TYPE.SET
                 else:
                     # Integers, Dates and Times, and other basic data is encoded in ascii
                     encoding = 'ascii'
             else:
                 encoding = None
+                if field_type == FIELD_TYPE.STRING and field.flags & FLAG.SET:
+                    field_type = FIELD_TYPE.SET
             converter = self.connection.decoders.get(field_type)
             if converter is converters.through:
                 converter = None


### PR DESCRIPTION
Currently this library convert SET field to string or leave it as raw bytes (when use_unicode flag is set to False). However, this appears to be incorrect behaviour.

The C API documentation [states](https://dev.mysql.com/doc/refman/8.0/en/c-api-data-structures.html):
> ENUM and SET values are returned as strings. For these, check that the type value is MYSQL_TYPE_STRING and that the ENUM_FLAG or SET_FLAG flag is set in the flags value.