### PR TITLE
Improve Connection's context manager

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -502,6 +502,7 @@ class Connection(object):
             self.rollback()
         else:
             self.commit()
+        self.close()
 
     # The following methods are INTERNAL USE ONLY (called from Cursor)
     def query(self, sql, unbuffered=False):

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -494,7 +494,7 @@ class Connection(object):
 
     def __enter__(self):
         """Context manager that returns a Cursor"""
-        return self.cursor()
+        return self
 
     def __exit__(self, exc, value, traceback):
         """On successful exit, commit. On exception, rollback"""


### PR DESCRIPTION
A class's context manager is expected to return an instance of the class and close all resources when exiting. This PR attempts to standardize the behaviour of the Connection class's context manager.