### PR TITLE
If socket is not detected, attempt a reconnect

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -741,6 +741,9 @@ class Connection(object):
         :raise InterfaceError: If the connection is closed.
         :raise ValueError: If no username was specified.
         """
+        if not self._sock and command != COMMAND.COM_PING:
+            self.ping(reconnect=True)
+        
         if not self._sock:
             raise err.InterfaceError("(0, '')")
 


### PR DESCRIPTION
We ran into issues where after MySQL drops, any queries afterward would hit this exception and never be able to recover. This extra conditional statement helps correct that. You can reproduce this issue every time by leaving the extension running, restart MySQL and then continue attempting to use the program using the extension and you will receive the null InterfaceError statement. 

By adding this ping/reconnect we have solved the issue of the program (JupyterHub) becoming unavailable after a while.