### PR TITLE
Cleanup after Python 2.6 support removed

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -302,8 +302,8 @@ class Connection(object):
             conv = converters.conversions
 
         # Need for MySQLdb compatibility.
-        self.encoders = dict([(k, v) for (k, v) in conv.items() if type(k) is not int])
-        self.decoders = dict([(k, v) for (k, v) in conv.items() if type(k) is int])
+        self.encoders = {k: v for (k, v) in conv.items() if type(k) is not int}
+        self.decoders = {k: v for (k, v) in conv.items() if type(k) is int}
         self.sql_mode = sql_mode
         self.init_command = init_command
         self.max_allowed_packet = max_allowed_packet

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -122,9 +122,9 @@ class Cursor(object):
             return tuple(conn.literal(arg) for arg in args)
         elif isinstance(args, dict):
             if PY2:
-                args = dict((ensure_bytes(key), ensure_bytes(val)) for
-                            (key, val) in args.items())
-            return dict((key, conn.literal(val)) for (key, val) in args.items())
+                args = {ensure_bytes(key): ensure_bytes(val) for
+                        (key, val) in args.items()}
+            return {key: conn.literal(val) for (key, val) in args.items()}
         else:
             # If it's not a dictionary let's try escaping it anyways.
             # Worst case it will throw a Value error

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy,pypy3
+envlist = py27,py34,py35,py36,py37,pypy,pypy3
 
 [testenv]
 commands = coverage run ./runtests.py


### PR DESCRIPTION
* Update `tox.ini` to match `.travis.yml` so Python 2.6 isn't listed there
* Use dictionary comprehensions where appropriate, a Python 2.7+ feature. They're a bit faster than creating a list and passing to `dict()`.