### PR TITLE
[converter] use isinstance() instead of type() to get the encoder

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -379,23 +379,27 @@ def get_encoder(val, mapping):
 
 
 encoders = {
+    text_type: escape_unicode,
+    # the order is important here: struct_time objects are also instances of tuple
+    # hence struct_time must come before tuple
+    time.struct_time: escape_struct_time,
     bool: escape_bool,
     int: escape_int,
     long_type: escape_int,
     float: escape_float,
     str: escape_str,
-    text_type: escape_unicode,
     tuple: escape_sequence,
     list: escape_sequence,
     set: escape_sequence,
     frozenset: escape_sequence,
     dict: escape_dict,
     type(None): escape_None,
-    datetime.date: escape_date,
+    # the order is important here: datetime objects are also instances of date
+    # hence datetime must come before date
     datetime.datetime: escape_datetime,
+    datetime.date: escape_date,
     datetime.timedelta: escape_timedelta,
     datetime.time: escape_time,
-    time.struct_time: escape_struct_time,
     Decimal: escape_object,
 }
 

--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -12,7 +12,7 @@ from .charset import charset_by_id, charset_to_encoding
 def escape_item(val, charset, mapping=None):
     if mapping is None:
         mapping = encoders
-    encoder = mapping.get(type(val))
+    encoder = get_encoder(val)
 
     # Fallback to default when no encoder found
     if not encoder:
@@ -368,6 +368,15 @@ def convert_characters(connection, field, data):
         data = data.decode(encoding)
         data = data.encode(connection.encoding)
     return data
+
+
+def get_encoder(val):
+    for type_, encoder in encoders.items():
+        if isinstance(val, type_):
+            return encoder
+    else:
+        return None
+
 
 encoders = {
     bool: escape_bool,

--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -12,7 +12,7 @@ from .charset import charset_by_id, charset_to_encoding
 def escape_item(val, charset, mapping=None):
     if mapping is None:
         mapping = encoders
-    encoder = get_encoder(val)
+    encoder = get_encoder(val, mapping)
 
     # Fallback to default when no encoder found
     if not encoder:
@@ -370,8 +370,8 @@ def convert_characters(connection, field, data):
     return data
 
 
-def get_encoder(val):
-    for type_, encoder in encoders.items():
+def get_encoder(val, mapping):
+    for type_, encoder in mapping.items():
         if isinstance(val, type_):
             return encoder
     else:


### PR DESCRIPTION
Hi methane - and the other contributors, thank you for your work!

In the converters, the `type(val) == some type` comparison does not support children of python standard classes, it leads to tricky bugs (I use the `faker` library to generate random `datetime` object and it was failing because faker `datetime` are instance of a child class of `datetime`).

This PR changes this comparison and uses `isinstance(val, some type)` instead. 

NB: There is a tricky part: `datetime` inherit from `date`, hence we need to select the last child of the subclass chain. It is the role of `get_relevant_type`. The builds of the first commits were failing because of that (datetime was casted to date), it's working now.