### PR TITLE
Fix cryptography version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cryptography
+cryptography==2.3.1
 


### PR DESCRIPTION
I propose that we use a specific version instead of the very latest. cryptography has very recently released a new version (2.4)  ttps://github.com/pyca/cryptography/releases and this update breaks some builds in the following manner.:   

```
Downloading https://files.pythonhosted.org/packages/d2/5f/6ed3135eb1e775187f7ecd4e7713f1415516725365e51f9786143f36e024/cryptography-2.4.1.tar.gz (468kB)
  Could not find a version that satisfies the requirement cffi!=1.11.3,>=1.7 (from versions: )
No matching distribution found for cffi!=1.11.3,>=1.7
```

Therefore I propose to use a specific version here instead of using the "latest". It is also good practice to use a specific version instead of the latest. Do you agree? Thanks.