### PR TITLE
Avoid ubyte format error when file path is too long (#750)

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -318,7 +318,7 @@ class Connection(object):
         if program_name is None:
             argv = getattr(sys, "argv")
             if argv:
-                program_name = argv[0]
+                program_name = os.path.basename(argv[0])
                 if PY2:
                     program_name = program_name.decode('utf-8', 'replace')
 


### PR DESCRIPTION
I opened issue #750 for this problem.
When I open a connection from a file that has a very long path, I got a ubyte format error.