### PR TITLE
Update error message for cryptography package

### DIFF
--- a/pymysql/_auth.py
+++ b/pymysql/_auth.py
@@ -139,7 +139,7 @@ def sha2_rsa_encrypt(password, salt, public_key):
     Used for sha256_password and caching_sha2_password.
     """
     if not _have_cryptography:
-        raise RuntimeError("cryptography is required for sha256_password or caching_sha2_password")
+        raise RuntimeError("The python package, cryptography, is required for sha256_password or caching_sha2_password. Obtain this package by running `pip install cryptography` and retry.")
     message = _xor_password(password + b'\0', salt)
     rsa_key = serialization.load_pem_public_key(public_key, default_backend())
     return rsa_key.encrypt(


### PR DESCRIPTION
Issue #768:

I just downloaded mysql (v8.0.13) and pymysql (v0.9.3) on my Mac (OS v10.14). This newest version of mysql now suggests encrypting passwords with SHA256 by default.

I was trying to connect to a database in mysql using:
```
import pymysql
con = pymysql.connect('localhost', 'testuser', 'testpw', 'testdb')
```

And got the error: `RuntimeError: cryptography is required for sha256_password or caching_sha2_password`

It took me 10 minutes or so on Google, and going to where this error was encoded on this github, to figure out that "cryptography" is just a package I need to pip install.

I've reworded the error message:
```
RuntimeError: The python package, cryptography, is required for sha256_password or caching_sha2_password. Obtain this package by running `pip install cryptography` and retry.
```