### PR TITLE
Add interface for non-file LOAD DATA LOCAL INFILE (#376)

### DIFF
--- a/pymysql/tests/test_load_local.py
+++ b/pymysql/tests/test_load_local.py
@@ -5,6 +5,20 @@ import os
 
 __all__ = ["TestLoadLocal"]
 
+class CountDown(object):
+
+    def read(self, max_packet_size):
+        if self._start:
+            self._start = self._start - 1
+            return (str(self._start) + "\n").encode()
+        return None
+
+    def __getitem__(self, obj):
+        try:
+            self._start = int(obj)
+            return self
+        except ValueError:
+            raise KeyError('Integers only')
 
 class TestLoadLocal(base.PyMySQLTestCase):
     def test_no_file(self):
@@ -63,6 +77,39 @@ class TestLoadLocal(base.PyMySQLTestCase):
             c = conn.cursor()
             c.execute("DROP TABLE test_load_local")
 
+    def test_generated_load_file(self):
+        """Test generated load local infile"""
+        conn = self.connect(local_infile=CountDown())
+        c = conn.cursor(cursors.SSCursor)
+        c.execute("CREATE TABLE test_load_local (a INTEGER)")
+
+        try:
+            c.execute(
+                "LOAD DATA LOCAL INFILE '99' INTO TABLE test_load_local"
+            )
+            c.execute("SELECT COUNT(*) FROM test_load_local")
+            self.assertEqual(99, c.fetchone()[0])
+        finally:
+            c.close()
+            conn.close()
+            conn.connect()
+            c = conn.cursor()
+            c.execute("DROP TABLE test_load_local")
+
+    def test_generated_no_file(self):
+        """Test load local infile when the generator rejects the filename"""
+        conn = self.connect(local_infile=CountDown())
+        c = conn.cursor()
+        c.execute("CREATE TABLE test_load_local (a INTEGER)")
+        try:
+            self.assertRaises(
+                OperationalError,
+                c.execute,
+                ("LOAD DATA LOCAL INFILE 'not_an_int' INTO TABLE test_load_local")
+            )
+        finally:
+            c.execute("DROP TABLE test_load_local")
+            c.close()
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
I saw the comments in #492.

LOAD DATA LOCAL INFILE is a rapid load mechanism in MySQL. ETL, machine learning, and specialized accelerators are some of the reasons that a rapid generation of data can occur. These are
application domains where Python is frequently used. Placing generated data into to a file before a load is an additional complication. This commit provides an alternate to temporary file generation.

I have a WIP for mysql-python in the same way as this is implemented - https://github.com/grooverdan/mysqlclient-python/commit/e3cd1d85414fb3f893ec954cef7c2b178defb3a4

I n the same way as mysql-python, this implementation mirrors https://dev.mysql.com/doc/refman/5.7/en/mysql-set-local-infile-handler.html

The dictionary look up is equivalent to `local_infile_init` which set `*ptr` as the object returned for a given `filename`.

`local_infile_read` is equivalent to the `read` call on the object.

The `local_infile_end` can be handled by the object clean-up.

local_infile_error is equivalent to raising an exception.

More completely:

In this commit the load_infile argument is changed from a boolean to optionally a dictionary. In true pythonic style, a dictionary implements `__getitem__` and during the client side LOAD DATA LOCAL INFILE implementation it is the filename that is looked up in the dictionary.

The object retrieved from the dictionary will have have its `read` method called (argument max_packet_size) to retrieve data as if it was the file being uploaded. The `read` method will return CSV, or otherwise separated, data as bytes. When the `read` method is complete it will return None.

closes #376