### PR TITLE
Setting SO_KEEPALIVE only for network connections

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -575,8 +575,9 @@ class Connection(object):
                     self.host_info = "socket %s:%d" % (self.host, self.port)
                     if DEBUG: print('connected using socket')
                     sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
                 sock.settimeout(None)
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+
             self._sock = sock
             self._rfile = _makefile(sock, 'rb')
             self._next_seq_id = 0


### PR DESCRIPTION
In the socket setup SO_KEEPALIVE (enabling TCP keepalive) is set after the if-branch between local unix and network sockets, setting it for both socket types. This works on Linux, but on Windows Subsystem for Linux, the `sock.setsockopt()` call returns EINVAL, which - while different from Linux - can be argued to make sense since a local unix socket can't really have a TCP keepalive setting.

By moving the SO_KEEPALIVE `sock.setsockopt()` call into the branch for network connections, it works on Wndows as well.