### PR TITLE
If `val` is an iterable, try encoding it using the `list` encoder.

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -1,5 +1,6 @@
 from ._compat import PY2, text_type, long_type, JYTHON, IRONPYTHON, unichr
 
+import collections
 import datetime
 from decimal import Decimal
 import re
@@ -14,8 +15,12 @@ def escape_item(val, charset, mapping=None):
         mapping = encoders
     encoder = mapping.get(type(val))
 
+    # If val is an iterable, try encoding it in whatever way we encode lists.
+    if encoder is None and isinstance(val, collections.Iterable):
+        encoder = mapping.get(list)
+
     # Fallback to default when no encoder found
-    if not encoder:
+    if encoder is None:
         try:
             encoder = mapping[text_type]
         except KeyError:

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -540,6 +540,24 @@ class TestEscape(base.PyMySQLTestCase):
         mapping[Foo] = escape_foo
         self.assertEqual(con.escape({'foo': Foo()}, mapping), {'foo': "bar"})
 
+    def test_escape_list(self):
+        con = self.connect()
+        cur = con.cursor()
+
+        self.assertEqual(con.escape([42, 43]), "(42,43)")
+
+    def test_escape_dict_keys(self):
+        con = self.connect()
+        cur = con.cursor()
+
+        self.assertEqual(con.escape({"one": 1, "two": 2}.keys()), "('one','two')")
+
+    def test_escape_dict_values(self):
+        con = self.connect()
+        cur = con.cursor()
+
+        self.assertEqual(con.escape({"one": 1, "two": 2}.values()), "(1,2)")
+
     def test_escape_list_item(self):
         con = self.connect()
         cur = con.cursor()


### PR DESCRIPTION
This is hopefullly a generic solution to
https://github.com/PyMySQL/PyMySQL/issues/531 that doesn't come with any
downsides.