### PR TITLE
Add ed25519 auth support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
       python: "2.7"
     - env:
         - DB=mariadb:10.3
+        - TEST_MARIADB_AUTH=yes
       python: "3.7"
     - env:
         - DB=mysql:5.5
@@ -46,7 +47,7 @@ matrix:
 # http://dev.mysql.com/downloads/mysql/5.7.html has latest development release version
 # really only need libaio1 for DB builds however libaio-dev is whitelisted for container builds and liaio1 isn't
 install:
-  - pip install -U coveralls coverage cryptography pytest pytest-cov
+  - pip install -U coveralls coverage cryptography PyNaCl pytest pytest-cov
 
 before_script:
   - ./.travis/initializedb.sh
@@ -57,7 +58,10 @@ before_script:
 script:
   - pytest -v --cov --cov-config .coveragerc pymysql
   - if [ "${TEST_AUTH}" = "yes" ];
-    then pytest -v --cov --cov-config .coveragerc tests;
+    then pytest -v --cov --cov-config .coveragerc tests/test_auth.py;
+    fi
+  - if [ "${TEST_MARIADB_AUTH}" = "yes" ];
+    then pytest -v --cov --cov-config .coveragerc tests/test_mariadb_auth.py;
     fi
   - if [ ! -z "${DB}" ];
     then docker logs mysqld;

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,11 @@ you need to install additional dependency::
 
    $ python3 -m pip install PyMySQL[rsa]
 
+To use MariaDB's "ed25519" authentication method, you need to install
+additional dependency::
+
+   $ python3 -m pip install PyMySQL[ed25519]
+
 
 Documentation
 -------------

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -894,6 +894,8 @@ class Connection(object):
             return _auth.sha256_password_auth(self, auth_packet)
         elif plugin_name == b"mysql_native_password":
             data = _auth.scramble_native_password(self.password, auth_packet.read_all())
+        elif plugin_name == b'client_ed25519':
+            data = _auth.ed25519_password(self.password, auth_packet.read_all())
         elif plugin_name == b"mysql_old_password":
             data = _auth.scramble_old_password(self.password, auth_packet.read_all()) + b'\0'
         elif plugin_name == b"mysql_clear_password":

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 cryptography
+PyNaCl>=1.4.0
 pytest

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     packages=find_packages(exclude=['tests*', 'pymysql.tests*']),
     extras_require={
         "rsa": ["cryptography"],
+        "ed25519": ["PyNaCl>=1.4.0"],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/test_mariadb_auth.py
+++ b/tests/test_mariadb_auth.py
@@ -1,0 +1,23 @@
+"""Test for auth methods supported by MariaDB 10.3+"""
+
+import pymysql
+
+# pymysql.connections.DEBUG = True
+# pymysql._auth.DEBUG = True
+
+host = "127.0.0.1"
+port = 3306
+
+
+def test_ed25519_no_password():
+    con = pymysql.connect(user="nopass_ed25519", host=host, port=port, ssl=None)
+    con.close()
+
+
+def test_ed25519_password():  # nosec
+    con = pymysql.connect(user="user_ed25519", password="pass_ed25519",
+                          host=host, port=port, ssl=None)
+    con.close()
+
+
+# default mariadb docker images aren't configured with SSL


### PR DESCRIPTION
Initial support for #786 based on PyNaCl. Currently, authentication is
limited to 32bytes-long passwords.