### PR TITLE
Let user set MySQLdb version

### DIFF
--- a/pymysql/__init__.py
+++ b/pymysql/__init__.py
@@ -123,7 +123,7 @@ def install_as_MySQLdb(MySQLdb_version=None):
     After this function is called, any application that imports MySQLdb or
     _mysql will unwittingly actually use pymysql.
     """
-    if type(MySQLdb_version) == tuple and len(MySQLdb_version) == 5:
+    if isinstance(MySQLdb_version, tuple) and len(MySQLdb_version) == 5:
         print("WARNING: Use at your own risk !!\nSet MySQLdb version = {}".format(MySQLdb_version))
         global version_info
         version_info = MySQLdb_version

--- a/pymysql/__init__.py
+++ b/pymysql/__init__.py
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
+from __future__ import print_function
 import sys
 
 from ._compat import PY2
@@ -123,11 +124,7 @@ def install_as_MySQLdb(MySQLdb_version=None):
     _mysql will unwittingly actually use pymysql.
     """
     if type(MySQLdb_version) == tuple and len(MySQLdb_version) == 5:
-        claim = "WARNING: Use at your own risk !!\nSet MySQLdb version = {}".format(MySQLdb_version)
-        if PY2:
-            print claim
-        else:
-            print(claim)
+        print("WARNING: Use at your own risk !!\nSet MySQLdb version = {}".format(MySQLdb_version))
         global version_info
         version_info = MySQLdb_version
     sys.modules["MySQLdb"] = sys.modules["_mysql"] = sys.modules["pymysql"]

--- a/pymysql/__init__.py
+++ b/pymysql/__init__.py
@@ -117,11 +117,19 @@ __version__ = get_client_info()
 def thread_safe():
     return True  # match MySQLdb.thread_safe()
 
-def install_as_MySQLdb():
+def install_as_MySQLdb(MySQLdb_version=None):
     """
     After this function is called, any application that imports MySQLdb or
     _mysql will unwittingly actually use pymysql.
     """
+    if type(MySQLdb_version) == tuple and len(MySQLdb_version) == 5:
+        claim = "WARNING: Use at your own risk !!\nSet MySQLdb version = {}".format(MySQLdb_version)
+        if PY2:
+            print claim
+        else:
+            print(claim)
+        global version_info
+        version_info = MySQLdb_version
     sys.modules["MySQLdb"] = sys.modules["_mysql"] = sys.modules["pymysql"]
 
 


### PR DESCRIPTION
Add an extra argument for setup MySQLdb version

To methane:
>Compatibility issue has been report multiple times.
> This patch lets user setup MySQLdb version for preventing new issue about MySQLdb version in future.
>
> Related issues:
>>#610 Compatibility with Django 2.0
>> #790 Compatibility with Django 2.2

To others:
> This is not the fix for #790 from PyMySQL side

> Fix from Django only applies to `master` branch, see [#30380](https://code.djangoproject.com/ticket/30380) for detail

> Backport to `stable/2.2.x` branch has been closed, see [Django PR#11318](https://github.com/django/django/pull/11318) for detail
> Please use other MySQL connector or avoid using `stable/2.2.x` at this time

Usage:
```python
import pymysql
pymysql.install_as_MySQLdb(MySQLdb_version=(1, 4, 2, "final", 0))
```