### PR TITLE
Added Function Handling

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -292,9 +292,10 @@ class Cursor(object):
 
             q = "SELECT %s(%s)" % (fnctname,
                                  ','.join(['@_%s_%d' % (fnctname, i)
-                                           for i in range_type(len(args))])) + "as `result`"
+                                           for i in range_type(len(args))])) + " AS `result`"
             self._query(q)
             self._executed = q
+            return args
 
     def fetchone(self):
         """Fetch the next row"""


### PR DESCRIPTION
Copied and modified the method 'callproc' to handle functions. Named the resulting method as 'callfnct'. This was done for two reasons:
1) To make function calls that are safe from SQL Injections.
2) Remove the need to know the parameters required by the function by an equivalent (psudeo) execute call, for example:
cursor.execute("SELECT fnctname(_arg1, arg2, arg3, ..._)", args)
=>
cursor.callfnct(fnctname, args)