### PR TITLE
set unbuffered_active = False before error raise

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -668,6 +668,8 @@ class Connection(object):
                 break
 
         packet = packet_type(bytes(buff), self.encoding)
+        if packet.is_error_packet() and self._result.unbuffered_active is True:
+            self._result.unbuffered_active = False
         packet.check_error()
         return packet
 


### PR DESCRIPTION
While  SSCursor closing for recieved a ERROR packet,  the client try to  [_finish_unbuffered_query ](https://github.com/PyMySQL/PyMySQL/blob/master/pymysql/connections.py#L1159)because  ` unbuffered_active` is still True, but the server would not send packets anymore.