### PR TITLE
More gracefully handles port coming in as string

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -276,6 +276,10 @@ class Connection(object):
         else:
             self.charset = DEFAULT_CHARSET
             self.use_unicode = False
+        
+        # Make sure port is an int.
+        if type(self.port) is not int:
+            raise ValueError("port should be of type int")
 
         if use_unicode is not None:
             self.use_unicode = use_unicode
@@ -550,9 +554,6 @@ class Connection(object):
     def connect(self, sock=None):
         self._closed = False
         try:
-            # Make sure port is an int.
-            if type(self.port) is not int:
-                raise socket.error("port should be of type int")
             if sock is None:
                 if self.unix_socket:
                     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -550,6 +550,9 @@ class Connection(object):
     def connect(self, sock=None):
         self._closed = False
         try:
+            # Make sure port is an int.
+            if not type(self.port) is int:
+                raise socket.error("port should be of type int")
             if sock is None:
                 if self.unix_socket:
                     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -278,7 +278,7 @@ class Connection(object):
         else:
             self.charset = DEFAULT_CHARSET
             self.use_unicode = False
-        
+
         if use_unicode is not None:
             self.use_unicode = use_unicode
 

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -254,6 +254,8 @@ class Connection(object):
 
         self.host = host or "localhost"
         self.port = port or 3306
+        if type(self.port) is not int:
+            raise ValueError("port should be of type int")
         self.user = user or DEFAULT_USER
         self.password = password or b""
         if isinstance(self.password, text_type):
@@ -277,10 +279,6 @@ class Connection(object):
             self.charset = DEFAULT_CHARSET
             self.use_unicode = False
         
-        # Make sure port is an int.
-        if type(self.port) is not int:
-            raise ValueError("port should be of type int")
-
         if use_unicode is not None:
             self.use_unicode = use_unicode
 

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -551,7 +551,7 @@ class Connection(object):
         self._closed = False
         try:
             # Make sure port is an int.
-            if not type(self.port) is int:
+            if type(self.port) is not int:
                 raise socket.error("port should be of type int")
             if sock is None:
                 if self.unix_socket:


### PR DESCRIPTION
Currently, the user gets an unhelpful TypeError for a common and simple mistake. This should help point them in the right direction.