### PR TITLE
add support for using password for keyfile passed in via dictionary

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -336,11 +336,7 @@ class Connection(object):
         ctx.check_hostname = not hasnoca and sslp.get('check_hostname', True)
         ctx.verify_mode = ssl.CERT_NONE if hasnoca else ssl.CERT_REQUIRED
         if 'cert' in sslp:
-            password = sslp.get('password')
-            if password:
-                ctx.load_cert_chain(sslp['cert'], keyfile=sslp.get('key'), password=password)
-            else:
-                ctx.load_cert_chain(sslp['cert'], keyfile=sslp.get('key'))
+            ctx.load_cert_chain(sslp['cert'], keyfile=sslp.get('key'), password=sslp.get('password'))
         if 'cipher' in sslp:
             ctx.set_ciphers(sslp['cipher'])
         ctx.options |= ssl.OP_NO_SSLv2

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -336,7 +336,11 @@ class Connection(object):
         ctx.check_hostname = not hasnoca and sslp.get('check_hostname', True)
         ctx.verify_mode = ssl.CERT_NONE if hasnoca else ssl.CERT_REQUIRED
         if 'cert' in sslp:
-            ctx.load_cert_chain(sslp['cert'], keyfile=sslp.get('key'))
+            password = sslp.get('password')
+            if password:
+                ctx.load_cert_chain(sslp['cert'], keyfile=sslp.get('key'), password=password)
+            else:
+                ctx.load_cert_chain(sslp['cert'], keyfile=sslp.get('key'))
         if 'cipher' in sslp:
             ctx.set_ciphers(sslp['cipher'])
         ctx.options |= ssl.OP_NO_SSLv2


### PR DESCRIPTION
add support for using password for keyfile passed in via sslp dictionary. works with load_cert_chain as described https://docs.python.org/3/library/ssl.html#ssl.SSLContext