### PR TITLE
Fix test suite compatibility with MySQL 8

### DIFF
--- a/pymysql/tests/test_basic.py
+++ b/pymysql/tests/test_basic.py
@@ -289,7 +289,7 @@ class TestBulkInserts(base.PyMySQLTestCase):
         self.safe_create_table(conn, 'bulkinsert', """\
 CREATE TABLE bulkinsert
 (
-id int(11),
+id int,
 name char(20),
 age int,
 height int,

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -79,8 +79,8 @@ class TestOldIssues(base.PyMySQLTestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
             c.execute("drop table if exists test")
-        c.execute("""CREATE TABLE `test` (`station` int(10) NOT NULL DEFAULT '0', `dh`
-datetime NOT NULL DEFAULT '2015-01-01 00:00:00', `echeance` int(1) NOT NULL
+        c.execute("""CREATE TABLE `test` (`station` int NOT NULL DEFAULT '0', `dh`
+datetime NOT NULL DEFAULT '2015-01-01 00:00:00', `echeance` int NOT NULL
 DEFAULT '0', `me` double DEFAULT NULL, `mo` double DEFAULT NULL, PRIMARY
 KEY (`station`,`dh`,`echeance`)) ENGINE=MyISAM DEFAULT CHARSET=latin1;""")
         try:


### PR DESCRIPTION
MySQL 8 deprecates the use of display format for int columns:

 https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html

This results in warnings being generated during test suite
execution which results in test failures.

Drop use of display widths - they don't materially change the tests
so this should be safe across all MySQL versions and variants.