### PR TITLE
updated doctored version info for MySQLdb compatibility

### DIFF
--- a/pymysql/__init__.py
+++ b/pymysql/__init__.py
@@ -108,7 +108,7 @@ def get_client_info():  # for MySQLdb compatibility
 connect = Connection = Connect
 
 # we include a doctored version_info here for MySQLdb compatibility
-version_info = (1, 3, 12, "final", 0)
+version_info = (1, 3, 13, "final", 0)
 
 NULL = "NULL"
 


### PR DESCRIPTION
Recent versions of Django require version 1.3.13 or later of MySQLdb. Otherwise `pymysql.install_as_MySQLdb()` throws an exception:

`django.core.exceptions.ImproperlyConfigured: mysqlclient 1.3.13 or newer is required; you have 0.9.3.`