### PR TITLE
Add support for `cadata` SSL connection option in addition to `ca` and `capath`

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -331,8 +331,9 @@ class Connection(object):
             return sslp
         ca = sslp.get('ca')
         capath = sslp.get('capath')
-        hasnoca = ca is None and capath is None
-        ctx = ssl.create_default_context(cafile=ca, capath=capath)
+        cadata = sslp.get('cadata')
+        hasnoca = ca is None and capath is None and cadata is None
+        ctx = ssl.create_default_context(cafile=ca, capath=capath, cadata=cadata)
         ctx.check_hostname = not hasnoca and sslp.get('check_hostname', True)
         ctx.verify_mode = ssl.CERT_NONE if hasnoca else ssl.CERT_REQUIRED
         if 'cert' in sslp:


### PR DESCRIPTION
Add support for `cadata` SSL connection option in addition to `ca` and `capath`.

Per [`ssl.create_default_context`](https://docs.python.org/3/library/ssl.html#ssl.create_default_context) this allows the CA certificate to be passed in directly as a string rather than as a file or directory name.