### PR TITLE
Add MySQL Connector/Python compatible SSL options.

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -254,14 +254,16 @@ class Connection(object):
 
         self.ssl = False
         if not ssl_disabled:
-            if ssl_cert or ssl_key or ssl_verify_cert or ssl_verify_identity:
+            if ssl_ca or ssl_cert or ssl_key or ssl_verify_cert or ssl_verify_identity:
                 ssl = {
                     "ca": ssl_ca,
-                    "cert": ssl_cert,
-                    "key": ssl_key,
                     "check_hostname": bool(ssl_verify_identity),
                     "verify_mode": ssl_verify_cert if ssl_verify_cert is not None else False,
                 }
+                if ssl_cert is not None:
+                    ssl["cert"] = ssl_cert
+                if ssl_key is not None:
+                    ssl["key" ] = ssl_key
             if ssl:
                 if not SSL_ENABLED:
                     raise NotImplementedError("ssl module not found")

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -152,6 +152,12 @@ class Connection(object):
         (default: 10, min: 1, max: 31536000)
     :param ssl:
         A dict of arguments similar to mysql_ssl_set()'s parameters.
+    :param ssl_ca: Path to the file that contains a PEM-formatted CA certificate
+    :param ssl_cert: Path to the file that contains a PEM-formatted client certificate
+    :param ssl_disabled: A boolean value that disables usage of TLS
+    :param ssl_key: Path to the file that contains a PEM-formatted private key for the client certificate
+    :param ssl_verify_cert: Set to true to check the validity of server certificates
+    :param ssl_verify_identity: Set to true to check the server's identity
     :param read_default_group: Group to read from in the configuration file.
     :param compress: Not supported
     :param named_pipe: Not supported
@@ -191,7 +197,9 @@ class Connection(object):
                  max_allowed_packet=16*1024*1024, defer_connect=False,
                  auth_plugin_map=None, read_timeout=None, write_timeout=None,
                  bind_address=None, binary_prefix=False, program_name=None,
-                 server_public_key=None):
+                 server_public_key=None, ssl_ca=None, ssl_cert=None,
+                 ssl_disabled=None, ssl_key=None, ssl_verify_cert=None,
+                 ssl_verify_identity=None):
         if use_unicode is None and sys.version_info[0] > 2:
             use_unicode = True
 
@@ -245,12 +253,21 @@ class Connection(object):
                         ssl[key] = value
 
         self.ssl = False
-        if ssl:
-            if not SSL_ENABLED:
-                raise NotImplementedError("ssl module not found")
-            self.ssl = True
-            client_flag |= CLIENT.SSL
-            self.ctx = self._create_ssl_ctx(ssl)
+        if not ssl_disabled:
+            if ssl_cert or ssl_key or ssl_verify_cert or ssl_verify_identity:
+                ssl = {
+                    "ca": ssl_ca,
+                    "cert": ssl_cert,
+                    "key": ssl_key,
+                    "check_hostname": bool(ssl_verify_identity),
+                    "verify_mode": ssl_verify_cert if ssl_verify_cert is not None else False,
+                }
+            if ssl:
+                if not SSL_ENABLED:
+                    raise NotImplementedError("ssl module not found")
+                self.ssl = True
+                client_flag |= CLIENT.SSL
+                self.ctx = self._create_ssl_ctx(ssl)
 
         self.host = host or "localhost"
         self.port = port or 3306
@@ -334,7 +351,22 @@ class Connection(object):
         hasnoca = ca is None and capath is None
         ctx = ssl.create_default_context(cafile=ca, capath=capath)
         ctx.check_hostname = not hasnoca and sslp.get('check_hostname', True)
-        ctx.verify_mode = ssl.CERT_NONE if hasnoca else ssl.CERT_REQUIRED
+        verify_mode_value = sslp.get('verify_mode')
+        if verify_mode_value is None:
+            ctx.verify_mode = ssl.CERT_NONE if hasnoca else ssl.CERT_REQUIRED
+        elif isinstance(verify_mode_value, bool):
+            ctx.verify_mode = ssl.CERT_REQUIRED if verify_mode_value else ssl.CERT_NONE
+        else:
+            if isinstance(verify_mode_value, (text_type, str_type)):
+                verify_mode_value = verify_mode_value.lower()
+            if verify_mode_value in ("none", "0", "false", "no"):
+                ctx.verify_mode = ssl.CERT_NONE
+            elif verify_mode_value == "optional":
+                ctx.verify_mode = ssl.CERT_OPTIONAL
+            elif verify_mode_value in ("required", "1", "true", "yes"):
+                ctx.verify_mode = ssl.CERT_REQUIRED
+            else:
+                ctx.verify_mode = ssl.CERT_NONE if hasnoca else ssl.CERT_REQUIRED
         if 'cert' in sslp:
             ctx.load_cert_chain(sslp['cert'], keyfile=sslp.get('key'))
         if 'cipher' in sslp:

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -520,6 +520,19 @@ class TestConnection(base.PyMySQLTestCase):
                         new=mock.Mock(return_value=dummy_ssl_context)) as create_default_context:
             pymysql.connect(
                 ssl_ca="ca",
+            )
+            assert create_default_context.called
+            assert not dummy_ssl_context.check_hostname
+            assert dummy_ssl_context.verify_mode == ssl.CERT_NONE
+            dummy_ssl_context.load_cert_chain.assert_not_called
+            dummy_ssl_context.set_ciphers.assert_not_called
+
+        dummy_ssl_context = mock.Mock(options=0)
+        with mock.patch("pymysql.connections.Connection.connect") as connect, \
+             mock.patch("pymysql.connections.ssl.create_default_context",
+                        new=mock.Mock(return_value=dummy_ssl_context)) as create_default_context:
+            pymysql.connect(
+                ssl_ca="ca",
                 ssl_cert="cert",
                 ssl_key="key",
             )
@@ -583,7 +596,6 @@ class TestConnection(base.PyMySQLTestCase):
         with mock.patch("pymysql.connections.Connection.connect") as connect, \
              mock.patch("pymysql.connections.ssl.create_default_context",
                         new=mock.Mock(return_value=dummy_ssl_context)) as create_default_context:
-            create_default_context.reset()
             pymysql.connect(
                 ssl_ca="ca",
                 ssl_cert="cert",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 cryptography
 PyNaCl>=1.4.0
 pytest
+mock


### PR DESCRIPTION
## Background of the modification

This patch adds a bunch of connection arguments that are compatible with MySQL Connector/Python.
https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html

The rationale for the change is that SQLAlchemy propagates the parameters specified in the DSN's query to the constructor arguments as they are, which means it cannot build a structured parameter to give it to the underlying connection factory. 
 MySQL Connector/Python can take unstructued TLS parameters so it plays well with SQLAlchemy.

## Details

This patch adds the following arguments:

* `ssl_ca`: Path to the file that contains a PEM-formatted CA certificate
* `ssl_cert`: Path to the file that contains a PEM-formatted client certificate
* `ssl_disabled`: A boolean value that disables usage of TLS
* `ssl_key`: Path to the file that contains a PEM-formatted private key for the client certificate
* `ssl_verify_cert`: Set to true to check the validity of server certificates
* `ssl_verify_identity`: Set to true to check the server's identity

This patch also introduces the following key for the dictionary that is supposed to be passed through `ssl` argument, which effectively closes #842.

* `verify_mode`: `none` for `ssl.CERT_NONE`, `optional` for `ssl.CERT_OPTIONAL` and `required` for `ssl.CERT_REQUIRED`

