### PR TITLE
fix test unix_socket for MariaDB-10.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # vim: sw=2 ts=2 sts=2 expandtab
 
-dist: xenial
+dist: bionic
 language: python
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,18 @@ matrix:
         - DB=mariadb:5.5
       python: "3.5"
     - env:
-        - DB=mariadb:10.0
+        - DB=mariadb:10.2
       python: "3.6"
     - env:
-        - DB=mariadb:10.1
+        - DB=mariadb:10.3
+        - TEST_MARIADB_AUTH=yes
       python: "pypy3"
     - env:
-        - DB=mariadb:10.2
+        - DB=mariadb:10.4
+        - TEST_MARIADB_AUTH=yes
       python: "2.7"
     - env:
-        - DB=mariadb:10.3
+        - DB=mariadb:10.5
         - TEST_MARIADB_AUTH=yes
       python: "3.7"
     - env:

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -70,7 +70,7 @@ class TestAuthentication(base.PyMySQLTestCase):
     for r in cur:
         if (r[1], r[2]) !=  (u'ACTIVE', u'AUTHENTICATION'):
             continue
-        if r[3] ==  u'auth_socket.so':
+        if r[3] ==  u'auth_socket.so' or r[0] == u'unix_socket':
             socket_plugin_name = r[0]
             socket_found = True
         elif r[3] ==  u'dialog_examples.so':


### PR DESCRIPTION
unix_socket is inbuilt in MariaDB-10.4+.

MariaDB-10.0 and 10.1 are out of support so replace these with MariaDB supported versions.

Like MySQL-5.5 keep MariaDB-5.5 as an oldest working version.