### PR TITLE
Set python_requires='>=3.6'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     description="Pure Python MySQL Driver",
     long_description=readme,
     packages=find_packages(exclude=["tests*", "pymysql.tests*"]),
+    python_requires=">=3.6",
     extras_require={
         "rsa": ["cryptography"],
         "ed25519": ["PyNaCl>=1.4.0"],


### PR DESCRIPTION
From your changelog seems like in the latest version you dropped Python 2 support but it is incomplete. You need to set python_requires in your setup.py that will prevent users with Python 2.7 from downloading a sdist version they cannot build.

Note: supporting python_requires requires setuptools>=24.2.0 and pip>=9.0.0 to benefit from it.
Details here: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

Here is the current issue if you try to install latest version of fastavro on Python 2:

```
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "c:\users\compile.rdv\appdata\local\temp\pip-install-_ifmxj\PyMySQL\setup.py", line 6, in <module>
        with open("./README.rst", encoding="utf-8") as f:
    TypeError: 'encoding' is an invalid keyword argument for this function
```

Also, the 1.0.0 version could be yanked. 