### PR TITLE
tox.ini: Fix incorrect dependency syntax

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,9 @@ envlist = py{36,37,38,39,py3}
 
 [testenv]
 commands = pytest -v pymysql/tests/
-deps = coverage pytest
+deps =
+          coverage
+          pytest
 passenv = USER
           PASSWORD
           PAMSERVICE


### PR DESCRIPTION
Fix the dependency syntax in tox.ini.  The current syntax results in:

    ERROR: Invalid requirement: 'coverage pytest'