### PR TITLE
Use built-in unittest.mock

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install dependency
         run: |
-          pip install -U cryptography PyNaCl pytest pytest-cov mock coveralls
+          pip install -U cryptography PyNaCl pytest pytest-cov coveralls
 
       - name: Set up MySQL
         run: |

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -1,10 +1,11 @@
 import datetime
 import ssl
 import sys
-import time
 import pytest
-import pymysql
+import time
 from unittest import mock
+
+import pymysql
 from pymysql.tests import base
 from pymysql.constants import CLIENT
 

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -2,9 +2,9 @@ import datetime
 import ssl
 import sys
 import time
-import mock
 import pytest
 import pymysql
+from unittest import mock
 from pymysql.tests import base
 from pymysql.constants import CLIENT
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 cryptography
 PyNaCl>=1.4.0
 pytest
-mock


### PR DESCRIPTION
Use built-in Python 3 unittest.mock instead of relying on mock package
that is only necessary for ancient versions of Python.