### PR TITLE
Close connection gracefully from Connection.__del__

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -427,7 +427,11 @@ class Connection:
         self._sock = None
         self._rfile = None
 
-    __del__ = _force_close
+    def __del__(self):
+        if not self._closed:
+            self.close()
+        else:
+            self._force_close()
 
     def autocommit(self, value):
         self.autocommit_mode = bool(value)

--- a/tests/test_del.py
+++ b/tests/test_del.py
@@ -1,0 +1,29 @@
+"""Test close() and __del__()"""
+
+import os
+import pymysql
+
+# pymysql.connections.DEBUG = True
+# pymysql._auth.DEBUG = True
+
+host = "127.0.0.1"
+port = 3306
+
+def test_close():
+    con = pymysql.connect(user="nopass_sha256", host=host, port=port, ssl=None)
+    con.close()
+
+def test_del():
+    con = pymysql.connect(user="nopass_sha256", host=host, port=port, ssl=None)
+    del con
+
+def test_close_and_explicit_del():
+    con = pymysql.connect(user="nopass_sha256", host=host, port=port, ssl=None)
+    con.close()
+    # Call __del__() explicitly as a test (don't do this in normal code)
+    con.__del__()
+
+def test_explicit_del():
+    con = pymysql.connect(user="nopass_sha256", host=host, port=port, ssl=None)
+    # Call __del__() explicitly as a test (don't do this in normal code)
+    con.__del__()

--- a/tests/test_del.py
+++ b/tests/test_del.py
@@ -9,19 +9,23 @@ import pymysql
 host = "127.0.0.1"
 port = 3306
 
+
 def test_close():
     con = pymysql.connect(user="nopass_sha256", host=host, port=port, ssl=None)
     con.close()
 
+
 def test_del():
     con = pymysql.connect(user="nopass_sha256", host=host, port=port, ssl=None)
     del con
+
 
 def test_close_and_explicit_del():
     con = pymysql.connect(user="nopass_sha256", host=host, port=port, ssl=None)
     con.close()
     # Call __del__() explicitly as a test (don't do this in normal code)
     con.__del__()
+
 
 def test_explicit_del():
     con = pymysql.connect(user="nopass_sha256", host=host, port=port, ssl=None)


### PR DESCRIPTION
Call close() from __del__() in Connection if the connection was not
already closed, to close the connection gracefully (i.e. first send
quite message to the server)

This solves issue #961 