### PR TITLE
Add optional ssl_cadata arg

### DIFF
--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -585,6 +585,24 @@ class TestConnection(base.PyMySQLTestCase):
             new=mock.Mock(return_value=dummy_ssl_context),
         ) as create_default_context:
             pymysql.connect(
+                ssl_cadata="cadata",
+                ssl_verify_cert=True,
+                ssl_verify_identity=True,
+            )
+            create_default_context.assert_called_with(
+                cafile=None, capath=None, cadata="cadata"
+            )
+            assert dummy_ssl_context.verify_mode == ssl.CERT_REQUIRED
+            assert dummy_ssl_context.check_hostname
+
+        dummy_ssl_context = mock.Mock(options=0)
+        with mock.patch(
+            "pymysql.connections.Connection.connect"
+        ) as connect, mock.patch(
+            "pymysql.connections.ssl.create_default_context",
+            new=mock.Mock(return_value=dummy_ssl_context),
+        ) as create_default_context:
+            pymysql.connect(
                 ssl_ca="ca",
                 ssl_cert="cert",
                 ssl_key="key",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,7 +10,9 @@ host = "127.0.0.1"
 port = 3306
 
 ca = os.path.expanduser("~/ca.pem")
+cadata = open(ca, "r").read()
 ssl = {"ca": ca, "check_hostname": False}
+ssl_cadata = {"cadata": cadata, "check_hostname": False}
 
 pass_sha256 = "pass_sha256_01234567890123456789"
 pass_caching_sha2 = "pass_caching_sha2_01234567890123456789"
@@ -23,6 +25,11 @@ def test_sha256_no_password():
 
 def test_sha256_no_passowrd_ssl():
     con = pymysql.connect(user="nopass_sha256", host=host, port=port, ssl=ssl)
+    con.close()
+
+
+def test_sha256_no_passowrd_ssl_cadata():
+    con = pymysql.connect(user="nopass_sha256", host=host, port=port, ssl=ssl_cadata)
     con.close()
 
 


### PR DESCRIPTION
Hi there, 

Starting with Python 3.4 `ssl` module supports providing CA certs via [cadata](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_verify_locations). I suppose it's useful If you'd like to dynamically fetch the certificate from somewhere and avoid having to create a temporary file. 

This is exactly the use case in https://github.com/awslabs/aws-data-wrangler/pull/664 - we would like to fetch MySQL connection details from [AWS Glue Connections](https://docs.aws.amazon.com/glue/latest/dg/connection-using.html), including the CA certificate stored in AWS S3, if configured, and pass them over to PyMySQL.
