### PR TITLE
Fix generating authentication response with long strings

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -898,10 +898,10 @@ class Connection:
             connect_attrs = b""
             for k, v in self._connect_attrs.items():
                 k = k.encode("utf-8")
-                connect_attrs += struct.pack("B", len(k)) + k
+                connect_attrs += _lenenc_int(len(k)) + k
                 v = v.encode("utf-8")
-                connect_attrs += struct.pack("B", len(v)) + v
-            data += struct.pack("B", len(connect_attrs)) + connect_attrs
+                connect_attrs += _lenenc_int(len(v)) + v
+            data += _lenenc_int(len(connect_attrs)) + connect_attrs
 
         self.write_packet(data)
         auth_packet = self._read_packet()


### PR DESCRIPTION
MySQL protocol uses special rules for string longer than 251 characters, listed here: https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse
PyMySQL has already been using this for unpacking server messages, but was not used for forming "handshake response" from a client.
We have discovered this on failing of automated tests under Jenkins which are executed at very long paths. By default, PyMySQL fills `program_name` with full path of the running script. The current version generates single byte 0xfe as full length of "client connect attrs".
The proposed patch utilizes already present _lenenc_int() for prefixing formed strings.
