### PR TITLE
keep the return type consistent whether there are results or not

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -298,7 +298,7 @@ class Cursor:
         """Fetch all the rows."""
         self._check_executed()
         if self._rows is None:
-            return ()
+            return []
         if self.rownumber:
             result = self._rows[self.rownumber :]
         else:


### PR DESCRIPTION
when:
    records1 = cursor.fetchall()
    records2 = cursor.fetchall()  # len(records2) == 0
    records = records1 + records2
problem encountered:
    TypeError: can only concatenate list (not "tuple") to list