### PR TITLE
Drop support of EOL Python and DB versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,18 +19,18 @@ jobs:
           - db: "mariadb:10.5"
             py: "3.7"
 
-          - db: "mysql:5.6"
-            py: "3.6"
+          - db: "mariadb:10.7"
+            py: "3.11-dev"
 
           - db: "mysql:5.7"
-            py: "pypy-3.6"
+            py: "pypy-3.8"
 
           - db: "mysql:8.0"
             py: "3.9"
             mysql_auth: true
 
           - db: "mysql:8.0"
-            py: "3.10-dev"
+            py: "3.10"
 
     services:
       mysql:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changes
 
+## v1.0.3
+
+Release date: TBD
+
+* Dropped support of end of life MySQL version 5.6
+* Dropped support of end of life MariaDB versions below 10.2
+* Dropped support of end of life Python version 3.6
+
+
 ## v1.0.2
 
 Release date: 2021-01-09

--- a/README.rst
+++ b/README.rst
@@ -25,13 +25,13 @@ Requirements
 
 * Python -- one of the following:
 
-  - CPython_ : 3.6 and newer
+  - CPython_ : 3.7 and newer
   - PyPy_ : Latest 3.x version
 
 * MySQL Server -- one of the following:
 
-  - MySQL_ >= 5.6
-  - MariaDB_ >= 10.0
+  - MySQL_ >= 5.7
+  - MariaDB_ >= 10.2
 
 .. _CPython: https://www.python.org/
 .. _PyPy: https://pypy.org/

--- a/docs/source/user/installation.rst
+++ b/docs/source/user/installation.rst
@@ -18,13 +18,13 @@ Requirements
 
 * Python -- one of the following:
 
-  - CPython_ >= 3.6
+  - CPython_ >= 3.7
   - Latest PyPy_ 3
 
 * MySQL Server -- one of the following:
 
-  - MySQL_ >= 5.6
-  - MariaDB_ >= 10.0
+  - MySQL_ >= 5.7
+  - MariaDB_ >= 10.2
 
 .. _CPython: http://www.python.org/
 .. _PyPy: http://pypy.org/

--- a/pymysql/tests/base.py
+++ b/pymysql/tests/base.py
@@ -32,6 +32,11 @@ class PyMySQLTestCase(unittest.TestCase):
         """Return True if the given connection is on the version given or
         greater.
 
+        This only checks the server version string provided when the
+        connection is established, therefore any check for a version tuple
+        greater than (5, 5, 5) will always fail on MariaDB, as it always
+        starts with 5.5.5, e.g. 5.5.5-10.7.1-MariaDB-1:10.7.1+maria~focal.
+
         e.g.::
 
             if self.mysql_server_is(conn, (5, 6, 4)):

--- a/pymysql/tests/test_basic.py
+++ b/pymysql/tests/test_basic.py
@@ -175,8 +175,6 @@ class TestConversion(base.PyMySQLTestCase):
         """test datetime conversion w microseconds"""
 
         conn = self.connect()
-        if not self.mysql_server_is(conn, (5, 6, 4)):
-            pytest.skip("target backend does not support microseconds")
         c = conn.cursor()
         dt = datetime.datetime(2013, 11, 12, 9, 9, 9, 123450)
         c.execute("create table test_datetime (id int, ts datetime(6))")
@@ -285,8 +283,10 @@ class TestCursor(base.PyMySQLTestCase):
         args = self.databases[0].copy()
         args["charset"] = "utf8mb4"
         conn = pymysql.connect(**args)
+        # MariaDB only has limited JSON support, stores data as longtext
+        # https://mariadb.com/kb/en/json-data-type/
         if not self.mysql_server_is(conn, (5, 7, 0)):
-            pytest.skip("JSON type is not supported on MySQL <= 5.6")
+            pytest.skip("JSON type is only supported on MySQL >= 5.7")
 
         self.safe_create_table(
             conn,

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -105,8 +105,6 @@ class TestAuthentication(base.PyMySQLTestCase):
 
     def test_plugin(self):
         conn = self.connect()
-        if not self.mysql_server_is(conn, (5, 5, 0)):
-            pytest.skip("MySQL-5.5 required for plugins")
         cur = conn.cursor()
         cur.execute(
             "select plugin from mysql.user where concat(user, '@', host)=current_user()"
@@ -401,13 +399,7 @@ class TestAuthentication(base.PyMySQLTestCase):
             self.databases[0]["database"],
             "sha256_password",
         ) as u:
-            if self.mysql_server_is(conn, (5, 7, 0)):
-                c.execute("SET PASSWORD FOR 'pymysql_sha256'@'localhost' ='Sh@256Pa33'")
-            else:
-                c.execute("SET old_passwords = 2")
-                c.execute(
-                    "SET PASSWORD FOR 'pymysql_sha256'@'localhost' = PASSWORD('Sh@256Pa33')"
-                )
+            c.execute("SET PASSWORD FOR 'pymysql_sha256'@'localhost' ='Sh@256Pa33'")
             c.execute("FLUSH PRIVILEGES")
             db = self.db.copy()
             db["password"] = "Sh@256Pa33"

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -466,29 +466,20 @@ class TestGitHubIssues(base.PyMySQLTestCase):
         )
 
         cur = conn.cursor()
-        # From MySQL 5.7, ST_GeomFromText is added and GeomFromText is deprecated.
-        if self.mysql_server_is(conn, (5, 7, 0)):
-            geom_from_text = "ST_GeomFromText"
-            geom_as_text = "ST_AsText"
-            geom_as_bin = "ST_AsBinary"
-        else:
-            geom_from_text = "GeomFromText"
-            geom_as_text = "AsText"
-            geom_as_bin = "AsBinary"
         query = (
             "INSERT INTO issue363 (id, geom) VALUES"
-            "(1998, %s('LINESTRING(1.1 1.1,2.2 2.2)'))" % geom_from_text
+            "(1998, ST_GeomFromText('LINESTRING(1.1 1.1,2.2 2.2)'))"
         )
         cur.execute(query)
 
         # select WKT
-        query = "SELECT %s(geom) FROM issue363" % geom_as_text
+        query = "SELECT ST_AsText(geom) FROM issue363"
         cur.execute(query)
         row = cur.fetchone()
         self.assertEqual(row, ("LINESTRING(1.1 1.1,2.2 2.2)",))
 
         # select WKB
-        query = "SELECT %s(geom) FROM issue363" % geom_as_bin
+        query = "SELECT ST_AsBinary(geom) FROM issue363"
         cur.execute(query)
         row = cur.fetchone()
         self.assertEqual(

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description="Pure Python MySQL Driver",
     long_description=readme,
     packages=find_packages(exclude=["tests*", "pymysql.tests*"]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     extras_require={
         "rsa": ["cryptography"],
         "ed25519": ["PyNaCl>=1.4.0"],
@@ -24,10 +24,11 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Intended Audience :: Developers",


### PR DESCRIPTION
- Python now requires 3.7+, reflected in python_requires
- MySQL now requires 5.7+ in tests
- MariaDB unchanged in tests, only dropped support in documentation

- Added Python 3.11 to test matrix
- Added MariaDB 10.7 to test matrix

- DB version checks have been removed from various tests where no longer needed.
this also results in running a few tests on MariaDB which were previously only
running on MySQL.

Due to the change in `python_requires` I don't think we're necessarily required to bump the version on major/minor level, let me know if you want me to adjust the PR for a different next version.

Fixes #1025