### PR TITLE
Modify the default port parameter to MySQL's default port 3306

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -169,7 +169,7 @@ class Connection:
         host=None,
         database=None,
         unix_socket=None,
-        port=0,
+        port=3306,
         charset="",
         sql_mode=None,
         read_default_file=None,


### PR DESCRIPTION
As the title shows, modify the default port parameter to MySQL's default port 3306, this way you don't have to enter port=3306 every time.