### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -492,7 +492,7 @@ class TestConnection(base.PyMySQLTestCase):
         time.sleep(2)
         with self.assertRaises(pymysql.OperationalError) as cm:
             cur.execute("SELECT 1+1")
-        # error occures while reading, not writing because of socket buffer.
+        # error occurs while reading, not writing because of socket buffer.
         # self.assertEqual(cm.exception.args[0], 2006)
         self.assertIn(cm.exception.args[0], (2006, 2013))
 

--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -149,7 +149,7 @@ KEY (`station`,`dh`,`echeance`)) ENGINE=MyISAM DEFAULT CHARSET=latin1;"""
         "test_issue_17() requires a custom, legacy MySQL configuration and will not be run."
     )
     def test_issue_17(self):
-        """could not connect mysql use passwod"""
+        """could not connect mysql use password"""
         conn = self.connect()
         host = self.databases[0]["host"]
         db = self.databases[0]["database"]


### PR DESCRIPTION
There are small typos in:
- pymysql/tests/test_connection.py
- pymysql/tests/test_issues.py

Fixes:
- Should read `password` rather than `passwod`.
- Should read `occurs` rather than `occures`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md