### PR TITLE
Fix CodeQL target branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '34 7 * * 2'
 


### PR DESCRIPTION
master branch was renamed to main some time ago, leading to this action no longer working properly, at least for PRs