### PR TITLE
Remove deprecated socket.error from Connection.connect exception handler

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -655,7 +655,7 @@ class Connection:
                 except:  # noqa
                     pass
 
-            if isinstance(e, (OSError, IOError, socket.error)):
+            if isinstance(e, (OSError, IOError)):
                 exc = err.OperationalError(
                     CR.CR_CONN_HOST_ERROR,
                     "Can't connect to MySQL server on %r (%s)" % (self.host, e),


### PR DESCRIPTION
Since python 3.3, `socket.error` is a deprecated alias for OSError, which is already included.

https://docs.python.org/3/library/socket.html#socket.error