### PR TITLE
Raise ProgrammingError on -np.inf in addition to np.inf

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -56,7 +56,7 @@ def escape_int(value, mapping=None):
 
 def escape_float(value, mapping=None):
     s = repr(value)
-    if s in ("inf", "nan"):
+    if s in ("inf", "-inf", "nan"):
         raise ProgrammingError("%s can not be used with MySQL" % s)
     if "e" not in s:
         s += "e0"


### PR DESCRIPTION
This addresses an issue that was posted in the pandas repo (https://github.com/pandas-dev/pandas/issues/34431).  The issue was resolved in pandas by catching different errors that are raised within pymysql and raising a consistent error in pandas, but a better solution is to make pymysql handle numpy.inf and -numpy.inf consistently.