### PR TITLE
Update cursors.py

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -130,8 +130,9 @@ class Cursor:
         """
         conn = self._get_db()
 
-        if args is not None:
-            query = query % self._escape_args(args, conn)
+        if args is not None:            
+            for i in self._escape_args(args, conn):
+                query = re.sub ( "[?]" ,i, query,count = 1)
 
         return query
 


### PR DESCRIPTION
mySQL ver 1.0.2 python version 3.10.6 Conda version 22.9.0 When self.__escape_args(args,conn)  = ('0', "'Chinua Achebe'", "'English'", "'Things Fall Apart'") query = "INSERT INTO book VALUES(?, ?, ?,?)"
got TypeError: not all arguements converted during string formatting