### PR TITLE
Connection pool feture

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,7 @@ The following examples make use of a simple table
 
 
 .. code:: python
+
     ## Use Connection Pool
 
     import pymysql.cursors

--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,7 @@ The following examples make use of a simple table
     ## Use Connection Pool
 
     import pymysql.cursors
+    import pymysql.pool
 
     # connect config
     mysql_settings = dict(

--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,53 @@ The following examples make use of a simple table
             print(result)
 
 
+.. code:: python
+    ## Use Connection Pool
+
+    import pymysql.cursors
+
+    # connect config
+    mysql_settings = dict(
+        host='localhost',
+        user='user',
+        password='passwd',
+        database='db',
+        cursorclass=pymysql.cursors.DictCursor
+    )
+
+    ## Create a ConnectionPool object
+    pool = pymysql.pool.ConnectionPool(min_idle=1, max_idle=3, **mysql_settings)
+
+    ## Get a connection object from the connection pool
+    # When the connection is used up, it will be automatically put back into the connection pool
+    # instead of closing the connection.
+
+    # * If you use the `with` statement, you don’t need to manually call the `close()` method.
+    #   When the connection object exits after use, it will be called automatically.
+    # * If you do not use the `with` statement, you need to manually call the `close()` method of the
+    #   connection after using the connection, or call the `return_connection(connection)` method of
+    #   the connection pool to return the connection to the connection pool.
+
+    connection = pool.get_connection()
+
+    with connection:
+        with connection.cursor() as cursor:
+            # Create a new record
+            sql = "INSERT INTO `users` (`email`, `password`) VALUES (%s, %s)"
+            cursor.execute(sql, ('webmaster@python.org', 'very-secret'))
+
+        # connection is not autocommit by default. So you must commit to save
+        # your changes.
+        connection.commit()
+
+        with connection.cursor() as cursor:
+            # Read a single record
+            sql = "SELECT `id`, `password` FROM `users` WHERE `email`=%s"
+            cursor.execute(sql, ('webmaster@python.org',))
+            result = cursor.fetchone()
+            print(result)
+
+
 This example will print:
 
 .. code:: python

--- a/pymysql/pool.py
+++ b/pymysql/pool.py
@@ -1,0 +1,298 @@
+import time
+from collections import deque
+
+from . import connections, err
+from .constants import COMMAND
+
+
+class PoolError(Exception):
+    """Pool Error"""
+
+
+class CreateConnectionError(PoolError):
+    """Create New Connection Error"""
+
+
+class GetConnectionError(PoolError):
+    """Get connection exception from connection pool"""
+
+
+class ReturnConnectionError(PoolError):
+    """Connection cannot return connection pool exception"""
+
+
+class Connection(connections.Connection):
+    """
+    OverWrite the Connection class of `pymysql.connections.Connection`
+
+    Create a connection object with or without connection pool properties,
+    which is the same as the instance created by `pymysql.connections.Connection`,
+    but adds some properties and methods related to connection pool.
+
+    OverWrite __exit__() and close() methods.
+    When the connection pool attribute is attached, it does not exit and close the connection,
+    but puts the connection back into the connection pool to reduce frequent connection creation.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(Connection, self).__init__(*args, **kwargs)
+        self._pool = None
+        self.last_connected = time.time()
+
+    def set_pool(self, pool: 'ConnectionPool') -> None:
+        """Set connection pool properties for a connection"""
+        self._pool = pool
+
+    def close(self):
+        """
+        Overwrite the close() method of `pymysql.connections.Connection`
+
+        With connection pooling (self._pool != None):
+            return the connection to the connection pool instead of closing the connection
+        Without connection pool (self._pool == None):
+            call the close() method of `pymysql.connections.Connection` to close the connection
+        """
+        if not self._pool:
+            super(Connection, self).close()
+        else:
+            self._pool.return_connection(self)
+
+    def ping(self, reconnect=True):
+        """
+        Overwrite the ping() method of `pymysql.connections.Connection`
+
+        Check if the server is available and if the communication between the client and the server are normal
+        When the check throws an exception:
+            1> close the old/broken connection
+            2> try to re-establish a new connection with the server
+
+        :param reconnect: If the connection is closed, reconnect.
+        :type reconnect: boolean
+
+        :raise Error: If the connection is closed and reconnect=False.
+        """
+        if self._sock is None:
+            if reconnect:
+                self.connect()
+                reconnect = False
+            else:
+                raise err.Error("Already closed")
+        try:
+            self._execute_command(COMMAND.COM_PING, "")
+            self._read_ok_packet()
+            # When the test passes, update the last connected field value
+            self.last_connected = time.time()
+        except Exception as exc:
+            if reconnect:
+                # When an exception occurs, close old/broken connection
+                if self._pool:
+                    self._force_close()
+
+                # try to establish a new connection
+                self.connect()
+                self.ping(False)
+            else:
+                raise exc
+
+    def __enter__(self) -> 'Connection':
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Overwrite the ping() method of `pymysql.connections.Connection`
+        When `self._pool != None`, and no exception occurs, the connection is returned to the connection pool,
+        otherwise the connection is closed.
+        """
+        if self._pool is not None:
+            if not exc_type:
+                # Reusable Connection, Return the connection to the connection pool
+                self._pool.return_connection(self)
+            else:
+                # No Reusable Connection, close connection
+                self._pool = None
+                try:
+                    super(Connection, self).close()
+                except Exception as exc:
+                    print(f'Warning: {self} __exit__ exception: {exc}')
+                    self._force_close()
+        else:
+            super(Connection, self).__exit__(self, exc_type, exc_val, exc_tb)
+
+
+class ConnectionPool(object):
+    """
+    Create a connection pool management object to store reusable connection objects
+    and reduce the number and overhead of frequent connection creation
+    """
+
+    def __init__(self, min_idle, max_idle, max_lifetime=3600, **kwargs):
+        """
+        :param min_idle: (Int) minimum number of idle connections
+        :param max_idle: (Int) maximum number of idle connections
+        :param max_lifetime: (Int | Float) connection maximum lifetime
+        :param kwargs: Dict, Connection object initialization parameters.
+                       refer to the `pymysql.connections.Connection`__init__() method parameters for details
+        """
+        # Verify connection pool configuration
+        if min_idle < 0:
+            raise PoolError('min_idle should be greater than 0')
+        if max_idle < min_idle:
+            raise PoolError('max_idle should be granter than min_idle')
+
+        self._min_idle = min_idle
+        self._max_idle = max_idle
+        self._lifetime = max_lifetime
+        self._closed = False
+        self._pool = deque(maxlen=self._max_idle)
+        self._kwargs = kwargs
+
+        # Record the total number of connections currently created
+        self._connect_num = deque()
+
+        # create min idle connection
+        for _ in range(self._min_idle):
+            conn = self._create_connection()
+            self._pool.appendleft(conn)
+            conn._returned = True  # Marks that the connection has been returned to the pool
+
+    def _create_connection(self):
+        """Create new connection"""
+        try:
+            conn = Connection(**self._kwargs)
+            conn.set_pool(self)
+            conn._returned = False
+            self._connect_num.append(1)
+            return conn
+        except Exception as exc:
+            raise CreateConnectionError(exc)
+
+    def _get_connection(self) -> Connection:
+        try:
+            return self._pool.pop()
+        except IndexError:
+            if self.connect_num < self.maxsize:
+                return self._create_connection()
+            else:
+                raise GetConnectionError(f'There are no idle connections in the connection pool.')
+
+    def get_connection(self, tries=3, delay=0.1, backoff=1, max_delay=30, ping=False) -> Connection:
+        """
+        Get an available connection object from the connection pool.
+
+        :param tries: the maximum number of attempts. default: 2.
+        :param delay: initial delay between attempts. default: 0.1.
+        :param backoff: multiplier applied to delay between attempts. default: 1.
+        :param max_delay: the maximum value of delay. default: 30.
+        :param ping: check connection availability. default: False.
+        """
+        if self.is_closed:
+            raise PoolError('ConnectionPool already closed')
+
+        assert tries >= 0, 'tries should be greater or equal than 0'
+        assert max_delay >= 0, 'max_delay should be greater or equal than 0'
+
+        # Limit the number of retry operations configuration
+        if tries > 10:
+            tries = 10
+        if max_delay > 60:
+            max_delay = 60
+
+        conn = None
+        while tries:
+            try:
+                conn = self._get_connection()
+                break
+            except Exception as exc:
+                tries -= 1
+                if not tries:
+                    raise GetConnectionError(exc)
+
+                time.sleep(delay)
+
+                delay *= backoff
+                if max_delay is not None:
+                    delay = min(delay, max_delay)
+        else:
+            if conn is None:
+                conn = self._get_connection()
+
+        # Check whether the connection has reached the maximum lifetime
+        if (time.time() - conn.last_connected + 0.1) > self._lifetime:
+            conn.set_pool = None
+            conn.close()
+            self._connect_num.pop()
+
+            # Connection expired, create a new connection object
+            return self._create_connection()
+        else:
+            if ping:
+                conn.ping(reconnect=True)
+            conn._returned = False
+            return conn
+
+    def return_connection(self, conn: Connection):
+        """Return the connection to the connection pool"""
+        if not hasattr(conn, '_pool') or getattr(conn, '_pool') is None or self.is_closed:
+            # When the connection does not have the pool attribute, the connection is dropped
+            conn.set_pool = None
+            conn.close()
+            conn._returned = True
+            self._connect_num.pop()
+            return
+
+        # close cursor object
+        conn.cursor().close()
+
+        if conn._returned:
+            raise ReturnConnectionError(f"This connection has already returned, connection: {conn}")
+
+        # Check whether the connection has reached the maximum lifetime
+        if (time.time() - conn.last_connected + 0.1) > self._lifetime:
+            conn.set_pool = None
+            conn.close()
+            self._connect_num.pop()
+
+            if self.connect_num < self.maxsize:
+                conn = self._create_connection()
+            else:
+                conn._returned = True
+                return
+        self._pool.appendleft(conn)
+        conn._returned = True
+
+    def close(self):
+        """Close the connection pool and the connection objects in the pool"""
+        self._closed = True
+        try:
+            while self._pool:
+                conn = self._pool.pop()
+                conn.set_pool = None
+                conn.close()
+                conn._returned = True
+                self._connect_num.pop()
+        except Exception as exc:
+            raise PoolError(f"Close the connection pool exception: {exc}")
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    @property
+    def size(self):
+        """Returns the number of available connections in the current pool"""
+        return len(self._pool)
+
+    @property
+    def maxsize(self):
+        """The maximum number of connections that the connection pool can hold"""
+        return self._max_idle
+
+    @property
+    def connect_num(self):
+        """Returns the total number of connections currently in the pool"""
+        return len(self._connect_num)
+
+    def __enter__(self) -> 'ConnectionPool':
+        return self
+
+    __exit__ = close

--- a/pymysql/tests/test_pool.py
+++ b/pymysql/tests/test_pool.py
@@ -53,7 +53,7 @@ def test_connection_pool_with_mutilThread():
         thread.start()
     for thread in threads:
         thread.join()
-    print('pool size:', pool.size)
+    print('pool size:', pool.size, 'pool connect quantity:', pool.connect_num)
 
 
 def test_connection_pool_with_threadPool():
@@ -64,3 +64,4 @@ def test_connection_pool_with_threadPool():
 
         for result in results:
             pass
+    print('pool size:', pool.size, 'pool connect quantity:', pool.connect_num)

--- a/pymysql/tests/test_pool.py
+++ b/pymysql/tests/test_pool.py
@@ -1,0 +1,66 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from pymysql.pool import Connection, ConnectionPool
+
+mysql_config = {
+    "host": "localhost",
+    "port": 3306,
+    "user": "root",
+    "password": "root",
+    "database": "test"
+}
+
+
+def test_connection():
+    with Connection(**mysql_config) as conn:
+        print("connection:", conn)
+        cur = conn.cursor()
+        cur.execute("show tables;")
+        print("result:", cur.fetchall())
+        cur.close()
+
+
+def opera(pool, num):
+    tn = threading.current_thread().name
+    conn = pool.get_connection(delay=0.3, backoff=1.2)
+    cur = conn.cursor()
+    cur.execute("show tables;")
+    print(f"Thread: {tn}, num: {num}, result: {cur.fetchall()}")
+    cur.close()
+    conn.close()
+
+
+def test_connection_pool():
+    pool = ConnectionPool(1, 3, **mysql_config)
+    print("pool:", pool)
+    conn = pool.get_connection()
+    print("connection:", conn)
+    cur = conn.cursor()
+    cur.execute("show tables;")
+    print("result:", cur.fetchall())
+    cur.close()
+    print('pool size:', pool.connect_num, '    pool idle connect num:', pool.size)
+    conn.close()
+    print('pool size:', pool.connect_num, '    pool idle connect num:', pool.size)
+
+
+def test_connection_pool_with_mutilThread():
+    pool = ConnectionPool(1, 5, **mysql_config)
+    print('connection pool:', pool)
+    threads = [threading.Thread(target=opera, args=(pool, num)) for num in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    print('pool size:', pool.size)
+
+
+def test_connection_pool_with_threadPool():
+    pool = ConnectionPool(1, 5, **mysql_config)
+    print('connection pool:', pool)
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        results = [executor.submit(opera, pool, num) for num in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]
+
+        for result in results:
+            pass

--- a/pymysql/tests/test_pool.py
+++ b/pymysql/tests/test_pool.py
@@ -6,9 +6,9 @@ from pymysql.pool import Connection, ConnectionPool
 mysql_config = {
     "host": "localhost",
     "port": 3306,
-    "user": "root",
-    "password": "root",
-    "database": "test"
+    "user": "user",
+    "password": "passwd",
+    "database": "db"
 }
 
 


### PR DESCRIPTION
### Add new function of connection pool

- Use connection pool
```python
import pymysql.cursors
import pymysql.pool

# connect config
mysql_settings = dict(
    host='localhost',
    user='user',
    password='passwd',
    database='db',
    cursorclass=pymysql.cursors.DictCursor
)

## Create a ConnectionPool object

pool = pymysql.pool.ConnectionPool(min_idle=1, max_idle=3, **mysql_settings)

## Get a connection object from the connection pool
# When the connection is used up, it will be automatically put back into the connection pool
# instead of closing the connection.

# * If you use the `with` statement, you don’t need to manually call the `close()` method.
#   When the connection object exits after use, it will be called automatically.
# * If you do not use the `with` statement, you need to manually call the `close()` method of the
#   connection after using the connection, or call the `return_connection(connection)` method of
#   the connection pool to return the connection to the connection pool.

connection = pool.get_connection()

with connection:      
    with connection.cursor() as cursor:  
        # Create a new Table
        create_table_sql = """
        CREATE TABLE `users` (
               `id` int(11) NOT NULL AUTO_INCREMENT,
               `email` varchar(255) COLLATE utf8_bin NOT NULL,
               `password` varchar(255) COLLATE utf8_bin NOT NULL,
               PRIMARY KEY (`id`)
           ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
           AUTO_INCREMENT=1 ;
        """
        cursor.execute(create_table_sql)
        
        # Create a new record
        sql = "INSERT INTO `users` (`email`, `password`) VALUES (%s, %s)"
        cursor.execute(sql, ('webmaster@python.org', 'very-secret'))

    # connection is not autocommit by default. So you must commit to save
    # your changes.
    connection.commit()

    with connection.cursor() as cursor:
        # Read a single record
        sql = "SELECT `id`, `password` FROM `users` WHERE `email`=%s"
        cursor.execute(sql, ('webmaster@python.org',))
        result = cursor.fetchone()
        print(result)
```

- Use connection pool (multithreading)
```python
import threading
import pymysql.pool

# connect config
mysql_settings = dict(
    host='localhost',
    user='user',
    password='passwd',
    database='db',
    cursorclass=pymysql.cursors.DictCursor
)

## Create a ConnectionPool object

pool = pymysql.pool.ConnectionPool(min_idle=1, max_idle=3, **mysql_settings)


def opera(conn_pool):
    tn = threading.current_thread().name
    conn = conn_pool.get_connection()
    cur = conn.cursor()
    cur.execute("show tables;")
    print(f"Thread: {tn}, connection: {conn}, result: {cur.fetchall()}")
    cur.close()
    conn.close()


threads = [threading.Thread(target=opera, args=(pool,)) for _ in range(5)]
for thread in threads:
    thread.start()
for thread in threads:
    thread.join()
print('pool size:', pool.size, 'pool created connect num', pool.connect_num)
```

- For more examples, please refer to the test case: `pymysql/tests/test_pool.py`