### PR TITLE
flake8: Use max_line_length instead of ignoring E501

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
-ignore = E203,E501,W503,E722
 exclude = tests,build,.venv,docs
+ignore = E203,W503,E722
+max_line_length=129
 
 [metadata]
 license = "MIT"


### PR DESCRIPTION
Rather than ignoring all long lines, it is better to set an upper limit on long lines.