### PR TITLE
Fix setuptools didn't include pymysql.constants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 namespaces = false
-include = ["pymysql"]
+include = ["pymysql*"]
 exclude = ["tests*", "pymysql.tests*"]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Fix #1095 