### PR TITLE
Cursor.fetchall() always return list.

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -282,6 +282,8 @@ class Cursor:
         """Fetch several rows."""
         self._check_executed()
         if self._rows is None:
+            # Django expects () for EOF.
+            # https://github.com/django/django/blob/0c1518ee429b01c145cf5b34eab01b0b92f8c246/django/db/backends/mysql/features.py#L8
             return ()
         end = self.rownumber + (size or self.arraysize)
         result = self._rows[self.rownumber : end]
@@ -292,7 +294,7 @@ class Cursor:
         """Fetch all the rows."""
         self._check_executed()
         if self._rows is None:
-            return ()
+            return []
         if self.rownumber:
             result = self._rows[self.rownumber :]
         else:
@@ -479,6 +481,10 @@ class SSCursor(Cursor):
                 break
             rows.append(row)
             self.rownumber += 1
+        if not rows:
+            # Django expects () for EOF.
+            # https://github.com/django/django/blob/0c1518ee429b01c145cf5b34eab01b0b92f8c246/django/db/backends/mysql/features.py#L8
+            return ()
         return rows
 
     def scroll(self, value, mode="relative"):

--- a/pymysql/tests/test_nextset.py
+++ b/pymysql/tests/test_nextset.py
@@ -38,7 +38,7 @@ class TestNextset(base.PyMySQLTestCase):
             self.assertEqual([(i,)], list(cur))
             with self.assertRaises(pymysql.ProgrammingError):
                 cur.nextset()
-            self.assertEqual((), cur.fetchall())
+            self.assertEqual([], cur.fetchall())
 
     def test_ok_and_next(self):
         cur = self.connect(client_flag=CLIENT.MULTI_STATEMENTS).cursor()


### PR DESCRIPTION
Cursor.fetchmany() returns empty tuple when exhausted all rows.
It is for Django compatibility.

Fix #1042.