### PR TITLE
Add `collation` option and `set_character_set()` to Connection

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -604,6 +604,12 @@ class Connection:
         self.set_character_set(charset)
 
     def set_character_set(self, charset, collation=None):
+        """
+        Set charaset (and collation)
+
+        Send "SET NAMES charset [COLLATE collation]" query.
+        Update Connection.encoding based on charset.
+        """
         # Make sure charset is supported.
         encoding = charset_by_name(charset).encoding
 
@@ -615,6 +621,7 @@ class Connection:
         self._read_packet()
         self.charset = charset
         self.encoding = encoding
+        self.collation = collation
 
     def connect(self, sock=None):
         self._closed = False

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -453,9 +453,9 @@ class TestConnection(base.PyMySQLTestCase):
         self.assertEqual(cur.fetchone(), ("latin1",))
         self.assertEqual(con.encoding, "cp1252")
 
-        con.set_character_set("utf8mb3", "utf8mb3_general_ci")
+        con.set_character_set("utf8mb4", "utf8mb4_general_ci")
         cur.execute("SELECT @@character_set_connection, @@collation_connection")
-        self.assertEqual(cur.fetchone(), ("utf8mb3", "utf8mb3_general_ci"))
+        self.assertEqual(cur.fetchone(), ("utf8mb4", "utf8mb4_general_ci"))
         self.assertEqual(con.encoding, "utf8")
 
     def test_largedata(self):

--- a/pymysql/tests/test_connection.py
+++ b/pymysql/tests/test_connection.py
@@ -444,6 +444,20 @@ class TestConnection(base.PyMySQLTestCase):
         arg["charset"] = "utf8mb4"
         pymysql.connect(**arg)
 
+    def test_set_character_set(self):
+        con = self.connect()
+        cur = con.cursor()
+
+        con.set_character_set("latin1")
+        cur.execute("SELECT @@character_set_connection")
+        self.assertEqual(cur.fetchone(), ("latin1",))
+        self.assertEqual(con.encoding, "cp1252")
+
+        con.set_character_set("utf8mb3", "utf8mb3_general_ci")
+        cur.execute("SELECT @@character_set_connection, @@collation_connection")
+        self.assertEqual(cur.fetchone(), ("utf8mb3", "utf8mb3_general_ci"))
+        self.assertEqual(con.encoding, "utf8")
+
     def test_largedata(self):
         """Large query and response (>=16MB)"""
         cur = self.connect().cursor()


### PR DESCRIPTION
Send `SET NAMES` on every new connection to ensure charset/collation are correctly configured.

Fix #1092