### PR TITLE
Allow PyMySQL to use encoding autodetection

### DIFF
--- a/ci/docker-entrypoint-initdb.d/README
+++ b/ci/docker-entrypoint-initdb.d/README
@@ -1,5 +1,7 @@
 To test with a MariaDB or MySQL container image:
 
+For Apple Silicon, add `--platform linux/amd64` to `docker run` parameters
+
 docker run -d -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=1 \
   --name=mysqld -v ./ci/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:z \
   mysql:8.0.26 --local-infile=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dynamic = ["version"]
 "ed25519" = [
     "PyNaCl>=1.4.0"
 ]
+"charset" = [
+    "charset-normalizer"
+]
 
 [project.urls]
 "Project" = "https://github.com/PyMySQL/PyMySQL"


### PR DESCRIPTION
This PR adds a new optional flag that enables usage of `charset-normalizer` package to detect the output encoding.

If this feature is accepted, I'll add some unit tests of course.