### PR TITLE
test json - mariadb without JSON type

### DIFF
--- a/pymysql/tests/test_basic.py
+++ b/pymysql/tests/test_basic.py
@@ -323,9 +323,10 @@ create table test_json (
         res = cur.fetchone()[0]
         self.assertEqual(json.loads(res), json.loads(json_str))
 
-        cur.execute("SELECT CAST(%s AS JSON) AS x", (json_str,))
-        res = cur.fetchone()[0]
-        self.assertEqual(json.loads(res), json.loads(json_str))
+        if self.get_mysql_vendor(conn) == "mysql":
+            cur.execute("SELECT CAST(%s AS JSON) AS x", (json_str,))
+            res = cur.fetchone()[0]
+            self.assertEqual(json.loads(res), json.loads(json_str))
 
 
 class TestBulkInserts(base.PyMySQLTestCase):


### PR DESCRIPTION
MariaDB-11.0.1 removed the 5.5.5 version hack (MDEV-28910).

MariaDB still doesn't support JSON as a type.

Use get_mysql_vendor() == mysql for the final part of test_json.

As tested: https://buildbot.mariadb.org/#/builders/158/builds/7720/steps/4/logs/stdio