### PR TITLE
Adds a new option for adding a timeout for ping

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -151,6 +151,7 @@ class Connection:
         (if no authenticate method) for returning a string from the user. (experimental)
     :param server_public_key: SHA256 authentication plugin public key value. (default: None)
     :param binary_prefix: Add _binary prefix on bytes and bytearray. (default: False)
+    :param timeout_on_ping: Set to true to re-use the connect_timeout for ping (default: False)
     :param compress: Not supported.
     :param named_pipe: Not supported.
     :param db: **DEPRECATED** Alias for database.
@@ -204,6 +205,7 @@ class Connection:
         ssl_key_password=None,
         ssl_verify_cert=None,
         ssl_verify_identity=None,
+        timeout_on_ping=False,
         compress=None,  # not supported
         named_pipe=None,  # not supported
         passwd=None,  # deprecated
@@ -311,6 +313,7 @@ class Connection:
         if write_timeout is not None and write_timeout <= 0:
             raise ValueError("write_timeout should be > 0")
         self._write_timeout = write_timeout
+        self._timeout_on_ping = timeout_on_ping
 
         self.charset = charset or DEFAULT_CHARSET
         self.collation = collation
@@ -590,7 +593,15 @@ class Connection:
                 reconnect = False
             else:
                 raise err.Error("Already closed")
+
+        read_timeout = self._read_timeout
+        write_timeout = self._write_timeout
+
         try:
+            if self._timeout_on_ping:
+                self._read_timeout = self.connect_timeout
+                self._write_timeout = self.connect_timeout
+
             self._execute_command(COMMAND.COM_PING, "")
             self._read_ok_packet()
         except Exception:
@@ -599,6 +610,10 @@ class Connection:
                 self.ping(False)
             else:
                 raise
+        finally:
+            if self._timeout_on_ping:
+                self._read_timeout = read_timeout
+                self._write_timeout = write_timeout
 
     def set_charset(self, charset):
         """Deprecated. Use set_character_set() instead."""


### PR DESCRIPTION
Attempt at https://github.com/PyMySQL/PyMySQL/issues/1169

====


The pymsql library currently supports a timeout for connect, reading, and writing, but there isn't a specific timeout for ping.

There's an interesting interaction between this library and a more high-level one, such as sqlalchemy. Many of the default classes for connection pools in sqlalchemy often allow for a pool_pre_ping option, which will ping the connection while checking it out of the pool. If the connection does not respond or is determined to be unconnected, then the pool will fetch a brand new connection.

Conceptually, this pre-pinging is essentially acting as a connect, however there is no way to timeout quickly if the connection is hangs or is in a bad state. One could set the read/write timeout to be low, but in practice this is difficult to do, as once a transaction is open or a connection is in use, then its reasonable to tolerate some read/write lag.

While it isn't necessarily the responsibility of this library to provide a ping that uses the connect timeout, it would be great to have an option to do so.