### PR TITLE
Add MariaDB mention in repo description and improve example with exception handling (#1180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # PyMySQL
 
-This package contains a pure-Python MySQL client library, based on [PEP
+This package contains a pure-Python MySQL and MariaDB client library, based on [PEP
 249](https://www.python.org/dev/peps/pep-0249/).
 
 ## Requirements
@@ -64,14 +64,13 @@ connection = pymysql.connect(host='localhost',
                              database='db',
                              cursorclass=pymysql.cursors.DictCursor)
 
-with connection:
+try:
     with connection.cursor() as cursor:
         # Create a new record
         sql = "INSERT INTO `users` (`email`, `password`) VALUES (%s, %s)"
         cursor.execute(sql, ('webmaster@python.org', 'very-secret'))
 
-    # connection is not autocommit by default. So you must commit to save
-    # your changes.
+    # Commit to save changes
     connection.commit()
 
     with connection.cursor() as cursor:
@@ -80,6 +79,12 @@ with connection:
         cursor.execute(sql, ('webmaster@python.org',))
         result = cursor.fetchone()
         print(result)
+
+except pymysql.MySQLError as e:
+    print(f"Error: {e}")
+
+finally:
+    connection.close()
 ```
 
 This example will print:


### PR DESCRIPTION
This PR addresses issue #1180, which requested adding MariaDB to the repository description, similar to how it was done for PyMySQL/mysqlclient in PyMySQL/mysqlclient#719.

Additionally, I updated the example code by incorporating try, except, and finally blocks to ensure proper error handling and cleanup when interacting with the database. This improves the robustness of the code and ensures that the connection is always closed, even in case of an error.

## Changes made:
- Added MariaDB to the repo description.
- Updated the example with error handling and resource management using try, except, and finally.

Let me know if further changes are needed.