### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,9 @@ jobs:
           - db: "mariadb:10.6"
             py: "3.12"
 
+          - db: "mariadb:10.6"
+            py: "3.13"
+
           - db: "mariadb:lts"
             py: "3.9"
 

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -40,8 +40,10 @@ try:
 
     DEFAULT_USER = getpass.getuser()
     del getpass
-except (ImportError, KeyError):
-    # KeyError occurs when there's no entry in OS database for a current user.
+except (ImportError, KeyError, OSError):
+    # When there's no entry in OS database for a current user:
+    # KeyError is raised in Python 3.12 and below.
+    # OSError is raised in Python 3.13+
     DEFAULT_USER = None
 
 DEBUG = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Intended Audience :: Developers",


### PR DESCRIPTION
- fixes #1188 
- Add python 3.13 to test matrix and pyproject.toml
