### PR TITLE
Resolve UTF8 charset case-insensitively

### DIFF
--- a/pymysql/charset.py
+++ b/pymysql/charset.py
@@ -45,9 +45,10 @@ class Charsets:
         return self._by_id[id]
 
     def by_name(self, name):
-        if name == "utf8":
-            name = "utf8mb4"
-        return self._by_name.get(name.lower())
+        lowercase_name = name.lower()
+        if lowercase_name == "utf8":
+            return self._by_name.get("utf8mb4")
+        return self._by_name.get(lowercase_name)
 
 
 _charsets = Charsets()

--- a/pymysql/charset.py
+++ b/pymysql/charset.py
@@ -45,10 +45,10 @@ class Charsets:
         return self._by_id[id]
 
     def by_name(self, name):
-        lowercase_name = name.lower()
-        if lowercase_name == "utf8":
+        name = name.lower()
+        if name == "utf8":
             return self._by_name.get("utf8mb4")
-        return self._by_name.get(lowercase_name)
+        return self._by_name.get(name)
 
 
 _charsets = Charsets()

--- a/pymysql/charset.py
+++ b/pymysql/charset.py
@@ -47,7 +47,7 @@ class Charsets:
     def by_name(self, name):
         name = name.lower()
         if name == "utf8":
-            return self._by_name.get("utf8mb4")
+            name = "utf8mb4"
         return self._by_name.get(name)
 
 

--- a/pymysql/tests/test_charset.py
+++ b/pymysql/tests/test_charset.py
@@ -21,5 +21,23 @@ def test_utf8():
     )
 
     # utf8 is alias of utf8mb4 since MySQL 8.0, and PyMySQL v1.1.
-    utf8 = pymysql.charset.charset_by_name("utf8")
-    assert utf8 == utf8mb4
+    lowercase_utf8 = pymysql.charset.charset_by_name("utf8")
+    assert lowercase_utf8 == utf8mb4
+
+    # Regardless of case, UTF8 (which is special cased) should resolve to the same thing
+    uppercase_utf8 = pymysql.charset.charset_by_name("UTF8")
+    mixedcase_utf8 = pymysql.charset.charset_by_name("UtF8")
+    assert uppercase_utf8 == lowercase_utf8
+    assert mixedcase_utf8 == lowercase_utf8
+
+def test_case_sensitivity():
+    lowercase_latin1 = pymysql.charset.charset_by_name("latin1")
+    assert lowercase_latin1 is not None
+
+    # lowercase and uppercase should resolve to the same charset
+    uppercase_latin1 = pymysql.charset.charset_by_name("LATIN1")
+    assert uppercase_latin1 == lowercase_latin1
+
+    # lowercase and mixed case should resolve to the same charset
+    mixedcase_latin1 = pymysql.charset.charset_by_name("LaTiN1")
+    assert mixedcase_latin1 == lowercase_latin1


### PR DESCRIPTION
Current behavior:
```
>>> from pymysql.charset import charset_by_name
>>> print(charset_by_name('UTF8'))
None
>>> print(charset_by_name('utf8'))
Charset(id=45, name='utf8mb4', collation='utf8mb4_general_ci')
>>> print(charset_by_name('latin1'))
Charset(id=8, name='latin1', collation='latin1_swedish_ci')
>>> print(charset_by_name('LATIN1'))
Charset(id=8, name='latin1', collation='latin1_swedish_ci')
```

where I think it's supposed to be able to case-insensitively resolve any `utf8` string into `utf8mb4`