### PR TITLE
security: prevent path traversal in LOAD DATA LOCAL INFILE

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -1447,7 +1447,15 @@ class MySQLResult:
 
 class LoadLocalFile:
     def __init__(self, filename, connection):
-        self.filename = filename
+        # Security: prevent path traversal via malicious server-provided filenames.
+        # Resolve to absolute path and reject traversal attempts.
+        self.filename = os.path.realpath(os.path.expanduser(filename))
+        cwd = os.path.realpath(os.getcwd())
+        if not self.filename.startswith(cwd + os.path.sep) and self.filename != cwd:
+            raise err.OperationalError(
+                CR.CR_LOAD_DATA_LOCAL_INFILE_REALPATH_FAIL,
+                f"File '{filename}' is outside the current working directory",
+            )
         self.connection = connection
 
     def send_data(self):

--- a/tests/test_load_local_file.py
+++ b/tests/test_load_local_file.py
@@ -1,0 +1,30 @@
+"""Tests for LOAD DATA LOCAL INFILE path traversal protection."""
+import os
+
+import pytest
+
+import pymysql
+from pymysql import err
+from pymysql.connections import LoadLocalFile
+from pymysql.constants import CR
+
+
+def test_load_local_file_rejects_path_traversal():
+    """A malicious server cannot read files outside the working directory."""
+    # Mock a minimal connection object
+    conn = object()
+
+    with pytest.raises(err.OperationalError) as exc_info:
+        LoadLocalFile("../../../etc/passwd", conn)
+
+    assert exc_info.value.args[0] == CR.CR_LOAD_DATA_LOCAL_INFILE_REALPATH_FAIL
+
+
+def test_load_local_file_rejects_absolute_path_outside_cwd():
+    """Absolute paths outside the working directory are rejected."""
+    conn = object()
+
+    with pytest.raises(err.OperationalError) as exc_info:
+        LoadLocalFile("/etc/passwd", conn)
+
+    assert exc_info.value.args[0] == CR.CR_LOAD_DATA_LOCAL_INFILE_REALPATH_FAIL


### PR DESCRIPTION
This PR fixes a path traversal vulnerability in LOAD DATA LOCAL INFILE handling.

**CWE:** CWE-22 (Path Traversal)
**File:** pymysql/connections.py

When local_infile=True is set on a connection, a malicious or compromised MySQL server can send a LOAD LOCAL INFILE request packet containing an arbitrary filename (e.g., ../../../etc/passwd). The client blindly opens the file and streams its contents back to the server.

**Fix:**
- In LoadLocalFile.__init__(), resolve the server-provided filename to an absolute path using os.path.realpath()
- Reject filenames that fall outside the current working directory
- Uses the existing CR_LOAD_DATA_LOCAL_INFILE_REALPATH_FAIL error code (which was defined but never referenced in the codebase)
- Added tests verifying path traversal and absolute path rejection

**Note:** The constant CR_LOAD_DATA_LOCAL_INFILE_REALPATH_FAIL = 2069 was already defined in pymysql/constants/CR.py, strongly suggesting that realpath validation was planned but never implemented. This PR completes that security hardening.
