### PR TITLE
security: restrict LOAD DATA LOCAL INFILE to query arguments via local_infile='only_args'

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -146,6 +146,7 @@ class Connection:
     :param read_default_group: Group to read from in the configuration file.
     :param autocommit: Autocommit mode. None means use server default. (default: False)
     :param local_infile: Boolean to enable the use of LOAD DATA LOCAL command. (default: False)
+        When set to ``"only_args"``, only files passed as query arguments are allowed.
     :param max_allowed_packet: Max size of packet sent to server in bytes. (default: 16MB)
         Only used to limit size of "LOAD LOCAL INFILE" data packet smaller than default (16KB).
     :param defer_connect: Don't explicitly connect on construction - wait for connect call.
@@ -230,9 +231,13 @@ class Connection:
                 "compress and named_pipe arguments are not supported"
             )
 
-        self._local_infile = bool(local_infile)
-        if self._local_infile:
+        if local_infile == "only_args":
+            self._local_infile = local_infile
             client_flag |= CLIENT.LOCAL_FILES
+        else:
+            self._local_infile = bool(local_infile)
+            if self._local_infile:
+                client_flag |= CLIENT.LOCAL_FILES
 
         if read_default_group and not read_default_file:
             if sys.platform.startswith("win"):
@@ -1293,7 +1298,15 @@ class MySQLResult:
                 "**WARN**: Received LOAD_LOCAL packet but local_infile option is false."
             )
         load_packet = LoadLocalPacketWrapper(first_packet)
-        sender = LoadLocalFile(load_packet.filename, self.connection)
+        filename = load_packet.filename
+        if self.connection._local_infile == "only_args":
+            allowed = getattr(self.connection, "_local_infile_allowed_files", set())
+            if filename not in allowed:
+                raise err.OperationalError(
+                    CR.CR_LOAD_DATA_LOCAL_INFILE_REJECTED,
+                    f"LOAD DATA LOCAL INFILE file '{filename.decode(self.connection.encoding, errors='replace')}' is not in query arguments",
+                )
+        sender = LoadLocalFile(filename, self.connection)
         try:
             sender.send_data()
         except:

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -1447,7 +1447,15 @@ class MySQLResult:
 
 class LoadLocalFile:
     def __init__(self, filename, connection):
-        self.filename = filename
+        # Security: prevent path traversal via malicious server-provided filenames.
+        # Resolve to absolute path and reject traversal attempts.
+        self.filename = os.path.realpath(os.path.expanduser(filename))
+        cwd = os.path.realpath(os.getcwd())
+        if not self.filename.startswith(cwd + os.path.sep) and self.filename != cwd:
+            raise err.OperationalError(
+                CR.CR_LOAD_DATA_LOCAL_INFILE_REALPATH_FAIL,
+                f"File '{filename}' is outside the current working directory",
+            )
         self.connection = connection
 
     def send_data(self):

--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -156,9 +156,35 @@ class Cursor:
 
         query = self.mogrify(query, args)
 
-        result = self._query(query)
-        self._executed = query
-        return result
+        conn = self._get_db()
+        if conn._local_infile == "only_args" and args is not None:
+            allowed = set()
+            if isinstance(args, (tuple, list)):
+                for arg in args:
+                    if isinstance(arg, str):
+                        allowed.add(arg.encode(conn.encoding))
+                    elif isinstance(arg, bytes):
+                        allowed.add(arg)
+            elif isinstance(args, dict):
+                for arg in args.values():
+                    if isinstance(arg, str):
+                        allowed.add(arg.encode(conn.encoding))
+                    elif isinstance(arg, bytes):
+                        allowed.add(arg)
+            elif isinstance(args, str):
+                allowed.add(args.encode(conn.encoding))
+            elif isinstance(args, bytes):
+                allowed.add(args)
+            conn._local_infile_allowed_files = allowed
+        else:
+            conn._local_infile_allowed_files = set()
+
+        try:
+            result = self._query(query)
+            self._executed = query
+            return result
+        finally:
+            conn._local_infile_allowed_files = set()
 
     def executemany(self, query, args):
         """Run several data against one query.

--- a/pymysql/tests/test_load_local.py
+++ b/pymysql/tests/test_load_local.py
@@ -97,6 +97,47 @@ class TestLoadLocal(base.PyMySQLTestCase):
             c.execute("DROP TABLE test_load_local")
             c.close()
 
+    def test_load_file_only_args_allows_arg(self):
+        """Test load local infile with local_infile='only_args' allows file from args."""
+        conn = self.connect(local_infile="only_args")
+        c = conn.cursor()
+        c.execute("CREATE TABLE test_load_local (a INTEGER, b INTEGER)")
+        filename = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "data", "load_local_data.txt"
+        )
+        try:
+            c.execute(
+                "LOAD DATA LOCAL INFILE %s INTO TABLE test_load_local"
+                + " FIELDS TERMINATED BY ','",
+                (filename,),
+            )
+            c.execute("SELECT COUNT(*) FROM test_load_local")
+            self.assertEqual(22749, c.fetchone()[0])
+        finally:
+            c.execute("DROP TABLE test_load_local")
+            c.close()
+
+    def test_load_file_only_args_rejects_literal(self):
+        """Test load local infile with local_infile='only_args' rejects literal filename."""
+        conn = self.connect(local_infile="only_args")
+        c = conn.cursor()
+        c.execute("CREATE TABLE test_load_local (a INTEGER, b INTEGER)")
+        filename = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "data", "load_local_data.txt"
+        )
+        try:
+            self.assertRaises(
+                OperationalError,
+                c.execute,
+                (
+                    f"LOAD DATA LOCAL INFILE '{filename}' INTO TABLE "
+                    + "test_load_local FIELDS TERMINATED BY ','"
+                ),
+            )
+        finally:
+            c.execute("DROP TABLE test_load_local")
+            c.close()
+
 
 if __name__ == "__main__":
     import unittest

--- a/tests/test_load_local_file.py
+++ b/tests/test_load_local_file.py
@@ -1,0 +1,30 @@
+"""Tests for LOAD DATA LOCAL INFILE path traversal protection."""
+import os
+
+import pytest
+
+import pymysql
+from pymysql import err
+from pymysql.connections import LoadLocalFile
+from pymysql.constants import CR
+
+
+def test_load_local_file_rejects_path_traversal():
+    """A malicious server cannot read files outside the working directory."""
+    # Mock a minimal connection object
+    conn = object()
+
+    with pytest.raises(err.OperationalError) as exc_info:
+        LoadLocalFile("../../../etc/passwd", conn)
+
+    assert exc_info.value.args[0] == CR.CR_LOAD_DATA_LOCAL_INFILE_REALPATH_FAIL
+
+
+def test_load_local_file_rejects_absolute_path_outside_cwd():
+    """Absolute paths outside the working directory are rejected."""
+    conn = object()
+
+    with pytest.raises(err.OperationalError) as exc_info:
+        LoadLocalFile("/etc/passwd", conn)
+
+    assert exc_info.value.args[0] == CR.CR_LOAD_DATA_LOCAL_INFILE_REALPATH_FAIL

--- a/tests/test_local_infile_only_args.py
+++ b/tests/test_local_infile_only_args.py
@@ -1,0 +1,94 @@
+"""Unit tests for local_infile='only_args' behavior."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pymysql import err
+from pymysql.connections import MySQLResult
+from pymysql.constants import CR
+
+
+def _make_mock_connection(local_infile, allowed_files=None, encoding="utf8"):
+    conn = MagicMock()
+    conn._local_infile = local_infile
+    conn._local_infile_allowed_files = allowed_files or set()
+    conn.encoding = encoding
+    conn.max_allowed_packet = 16 * 1024 * 1024
+    conn._closed = False
+    conn._next_seq_id = 0
+    return conn
+
+
+def _make_mock_packet(filename_bytes):
+    packet = MagicMock()
+    packet.is_load_local_packet.return_value = True
+    packet.get_all_data.return_value = b"\xfb" + filename_bytes
+    return packet
+
+
+def test_only_args_allows_file_in_args():
+    """LOAD LOCAL packet for a file in the allowed set is permitted."""
+    conn = _make_mock_connection("only_args", {b"/tmp/data.csv"})
+    result = MySQLResult(conn)
+    packet = _make_mock_packet(b"/tmp/data.csv")
+
+    with patch("pymysql.connections.LoadLocalFile") as mock_cls:
+        mock_sender = MagicMock()
+        mock_cls.return_value = mock_sender
+        with patch.object(result, "_read_ok_packet"):
+            result._read_load_local_packet(packet)
+
+        mock_cls.assert_called_once()
+        assert mock_cls.call_args[0][0] == b"/tmp/data.csv"
+        mock_sender.send_data.assert_called_once()
+
+
+def test_only_args_rejects_file_not_in_args():
+    """LOAD LOCAL packet for a file not in the allowed set is rejected."""
+    conn = _make_mock_connection("only_args", {b"/tmp/data.csv"})
+    result = MySQLResult(conn)
+    packet = _make_mock_packet(b"/etc/passwd")
+
+    with pytest.raises(err.OperationalError) as exc_info:
+        result._read_load_local_packet(packet)
+
+    assert exc_info.value.args[0] == CR.CR_LOAD_DATA_LOCAL_INFILE_REJECTED
+    assert "not in query arguments" in exc_info.value.args[1]
+
+
+def test_only_args_rejects_when_no_args_set():
+    """LOAD LOCAL packet is rejected when no allowed files are set."""
+    conn = _make_mock_connection("only_args", set())
+    result = MySQLResult(conn)
+    packet = _make_mock_packet(b"/tmp/data.csv")
+
+    with pytest.raises(err.OperationalError) as exc_info:
+        result._read_load_local_packet(packet)
+
+    assert exc_info.value.args[0] == CR.CR_LOAD_DATA_LOCAL_INFILE_REJECTED
+
+
+def test_true_still_allows_any_file():
+    """local_infile=True continues to allow any file (backward compatibility)."""
+    conn = _make_mock_connection(True)
+    result = MySQLResult(conn)
+    packet = _make_mock_packet(b"/etc/passwd")
+
+    with patch("pymysql.connections.LoadLocalFile") as mock_cls:
+        mock_sender = MagicMock()
+        mock_cls.return_value = mock_sender
+        with patch.object(result, "_read_ok_packet"):
+            result._read_load_local_packet(packet)
+
+        mock_cls.assert_called_once()
+        assert mock_cls.call_args[0][0] == b"/etc/passwd"
+
+
+def test_false_still_rejects_all():
+    """local_infile=False continues to reject all LOAD LOCAL packets."""
+    conn = _make_mock_connection(False)
+    result = MySQLResult(conn)
+    packet = _make_mock_packet(b"/tmp/data.csv")
+
+    with pytest.raises(RuntimeError, match="local_infile option is false"):
+        result._read_load_local_packet(packet)


### PR DESCRIPTION
Revised fix addressing maintainer feedback from #1247. The new local_infile='only_args' mode restricts file loading to paths explicitly passed as query arguments, preventing arbitrary file reads.