### PR TITLE
Fix bare except in _read_load_local_packet: use except Exception

### DIFF
--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -1296,7 +1296,7 @@ class MySQLResult:
         sender = LoadLocalFile(load_packet.filename, self.connection)
         try:
             sender.send_data()
-        except:
+        except Exception:
             self.connection._read_packet()  # skip ok packet
             raise
 


### PR DESCRIPTION
In `_read_load_local_packet`, the bare `except:` clause catches `BaseException`, which includes `KeyboardInterrupt` and `SystemExit`. This can suppress Ctrl+C interrupts and interpreter shutdown signals.

```python
# Before
try:
    sender.send_data()
except:
    self.connection._read_packet()  # skip ok packet
    raise

# After
try:
    sender.send_data()
except Exception:
    self.connection._read_packet()  # skip ok packet
    raise
```

Since `send_data()` raises normal `Exception` subclasses (like `OSError`, `IOError`) and the clause re-raises anyway, `except Exception:` is the correct scope here. `KeyboardInterrupt` and `SystemExit` should propagate without the cleanup step.