### PR TITLE
Encode string passwords as UTF-8

### DIFF
--- a/ci/docker-entrypoint-initdb.d/mysql.sql
+++ b/ci/docker-entrypoint-initdb.d/mysql.sql
@@ -1,7 +1,7 @@
 /*!80001 CREATE USER
                   user_sha256   IDENTIFIED WITH "sha256_password" BY "pass_sha256_01234567890123456789",
                   nopass_sha256 IDENTIFIED WITH "sha256_password",
-                  user_caching_sha2   IDENTIFIED WITH "caching_sha2_password" BY "pass_caching_sha2_01234567890123456789",
+                  user_caching_sha2   IDENTIFIED WITH "caching_sha2_password" BY "pass_caching_sha2_密码",
                   nopass_caching_sha2 IDENTIFIED WITH "caching_sha2_password"
                   PASSWORD EXPIRE NEVER */;
 

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -309,7 +309,7 @@ class Connection:
         self.user = user or DEFAULT_USER
         self.password = password or b""
         if isinstance(self.password, str):
-            self.password = self.password.encode("latin1")
+            self.password = self.password.encode("utf-8")
         self.db = database
         self.unix_socket = unix_socket
         self.bind_address = bind_address

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -13,7 +13,7 @@ ca = os.path.expanduser("~/ca.pem")
 ssl = {"ca": ca, "check_hostname": False}
 
 pass_sha256 = "pass_sha256_01234567890123456789"
-pass_caching_sha2 = "pass_caching_sha2_01234567890123456789"
+pass_caching_sha2 = "pass_caching_sha2_密码"
 
 
 def test_sha256_no_password():


### PR DESCRIPTION
## Summary

- encode string passwords as UTF-8 instead of Latin-1 before authentication
- exercise the existing `caching_sha2_password` integration tests with a non-Latin-1 password

## Root cause and impact

`Connection` eagerly encoded every string password with Latin-1. Passwords containing characters outside that codec raised `UnicodeEncodeError` before a connection or authentication attempt could begin. Encoding at the shared connection boundary fixes every built-in authentication plugin while preserving byte passwords unchanged.

The existing MySQL authentication matrix now uses a password containing Chinese characters, so CI verifies the complete handshake against MySQL 8.0, 8.4, and 9.

Fixes #1252

## Validation

- reproduced the pre-fix `UnicodeEncodeError` with a non-Latin-1 password
- verified the connection stores the expected UTF-8 bytes after the fix
- collected all 8 tests in `tests/test_auth.py`
- `ruff format --check pymysql/connections.py tests/test_auth.py`
- `ruff check --select E9,F63,F7,F82 pymysql/connections.py tests/test_auth.py`
- `git diff --check`
