### PR TITLE
Fix escape_timedelta for negative values

### DIFF
--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -100,19 +100,19 @@ def escape_timedelta(obj, mapping=None):
     # non-negative and the sign lives entirely in days, so the signed magnitude
     # must be reconstructed before it is split into hours/minutes/seconds --
     # otherwise a negative TIME comes out with complemented sub-hour fields.
-    total_us = (obj.days * 86400 + obj.seconds) * 1000000 + obj.microseconds
-    sign = "-" if total_us < 0 else ""
-    total_us = abs(total_us)
-    microseconds = total_us % 1000000
-    total_seconds = total_us // 1000000
-    seconds = total_seconds % 60
-    minutes = (total_seconds // 60) % 60
-    hours = total_seconds // 3600
-    if microseconds:
-        fmt = "'{0}{1:02d}:{2:02d}:{3:02d}.{4:06d}'"
-    else:
-        fmt = "'{0}{1:02d}:{2:02d}:{3:02d}'"
-    return fmt.format(sign, hours, minutes, seconds, microseconds)
+    sign = ''
+    if obj.days < 0:
+        sign = '-'
+        obj = abs(obj)
+
+    micros = obj.microseconds
+    minutes, seconds = divmod(obj.seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    hours += obj.days * 24
+
+    if micros:
+        return f"'{sign}{hours:02d}:{minutes:02d}:{seconds:02d}.{micros:06d}'"
+    return f"'{sign}{hours:02d}:{minutes:02d}:{seconds:02d}'"
 
 
 def escape_time(obj, mapping=None):

--- a/pymysql/converters.py
+++ b/pymysql/converters.py
@@ -96,14 +96,23 @@ def escape_None(value, mapping=None):
 
 
 def escape_timedelta(obj, mapping=None):
-    seconds = int(obj.seconds) % 60
-    minutes = int(obj.seconds // 60) % 60
-    hours = int(obj.seconds // 3600) % 24 + int(obj.days) * 24
-    if obj.microseconds:
-        fmt = "'{0:02d}:{1:02d}:{2:02d}.{3:06d}'"
+    # timedelta normalizes a negative value so that seconds/microseconds are
+    # non-negative and the sign lives entirely in days, so the signed magnitude
+    # must be reconstructed before it is split into hours/minutes/seconds --
+    # otherwise a negative TIME comes out with complemented sub-hour fields.
+    total_us = (obj.days * 86400 + obj.seconds) * 1000000 + obj.microseconds
+    sign = "-" if total_us < 0 else ""
+    total_us = abs(total_us)
+    microseconds = total_us % 1000000
+    total_seconds = total_us // 1000000
+    seconds = total_seconds % 60
+    minutes = (total_seconds // 60) % 60
+    hours = total_seconds // 3600
+    if microseconds:
+        fmt = "'{0}{1:02d}:{2:02d}:{3:02d}.{4:06d}'"
     else:
-        fmt = "'{0:02d}:{1:02d}:{2:02d}'"
-    return fmt.format(hours, minutes, seconds, obj.microseconds)
+        fmt = "'{0}{1:02d}:{2:02d}:{3:02d}'"
+    return fmt.format(sign, hours, minutes, seconds, microseconds)
 
 
 def escape_time(obj, mapping=None):

--- a/pymysql/tests/test_converters.py
+++ b/pymysql/tests/test_converters.py
@@ -45,6 +45,26 @@ class TestConverter(TestCase):
         self._test_convert_timedelta(with_negate=False, with_fsp=True)
         self._test_convert_timedelta(with_negate=False, with_fsp=True)
 
+    def test_escape_timedelta(self):
+        # MySQL TIME allows negatives, and a timedelta is the registered param
+        # encoder, so a negative value must escape to its real magnitude with a
+        # single leading sign -- not with complemented sub-hour fields.
+        cases = {
+            datetime.timedelta(hours=1, minutes=30): "'01:30:00'",
+            datetime.timedelta(days=1, hours=2): "'26:00:00'",
+            -datetime.timedelta(minutes=30): "'-00:30:00'",
+            -datetime.timedelta(hours=1, minutes=30): "'-01:30:00'",
+            datetime.timedelta(seconds=83579, microseconds=51000): "'23:12:59.051000'",
+            -datetime.timedelta(seconds=83579, microseconds=51000): "'-23:12:59.051000'",
+        }
+        for tdelta, expected in cases.items():
+            self.assertEqual(converters.escape_timedelta(tdelta), expected)
+            # the escaped literal must re-parse to the same duration
+            self.assertEqual(
+                converters.convert_timedelta(converters.escape_timedelta(tdelta).strip("'")),
+                tdelta,
+            )
+
     def test_convert_time(self):
         expected = datetime.time(23, 6, 20)
         time_obj = converters.convert_time("23:06:20")


### PR DESCRIPTION
`escape_timedelta` produced the wrong SQL literal for a negative `timedelta`. Python normalizes a negative `timedelta` so `seconds`/`microseconds` are non-negative and the sign lives entirely in `days`, but `escape_timedelta` decomposed the always-positive `seconds` and applied the sign only through `days*24`. A negative value therefore came out with complemented sub-hour fields — `-timedelta(minutes=30)` escaped to `'-1:30:00'` (-5400s) instead of `'-00:30:00'`.

MySQL TIME allows negatives (`-838:59:59`..`838:59:59`) and a `timedelta` is the registered encoder for TIME parameters, so this silently corrupts a negative TIME bound as a parameter. Reconstruct the signed magnitude first, then format the absolute value with a single leading sign. Added a test.
