### PR TITLE
Encode string passwords as UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+* Encode string passwords as UTF-8 instead of Latin-1. (#1252)
+
 ## v1.2.0
 
 Release date: 2026-05-19

--- a/pymysql/connections.py
+++ b/pymysql/connections.py
@@ -307,7 +307,7 @@ class Connection:
         self.user = user or DEFAULT_USER
         self.password = password or b""
         if isinstance(self.password, str):
-            self.password = self.password.encode("latin1")
+            self.password = self.password.encode("utf-8")
         self.db = database
         self.unix_socket = unix_socket
         self.bind_address = bind_address

--- a/pymysql/tests/test_charset.py
+++ b/pymysql/tests/test_charset.py
@@ -1,3 +1,4 @@
+import pymysql
 import pymysql.charset
 
 
@@ -42,3 +43,8 @@ def test_case_sensitivity():
     # lowercase and mixed case should resolve to the same charset
     mixedcase_latin1 = pymysql.charset.charset_by_name("LaTiN1")
     assert mixedcase_latin1 == lowercase_latin1
+
+
+def test_password_encoded_as_utf8():
+    conn = pymysql.connect(defer_connect=True, password="café")
+    assert conn.password == "café".encode("utf-8")


### PR DESCRIPTION
Fixes #1252.

`Connection` still encoded string passwords with latin1 even though the default charset has been utf-8 for a while. Bytes passwords are left alone.

This is a behavior change for passwords that aren't latin1, which I think is what you wanted for the next minor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - String passwords containing non-ASCII characters are now encoded as UTF-8 during authentication, improving compatibility with international passwords.

- **Documentation**
  - Added an unreleased changelog entry describing the password encoding update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->