### PR TITLE
test: add reproduction test for callproc multi-resultsets with OUT params

### DIFF
--- a/pymysql/tests/test_issues.py
+++ b/pymysql/tests/test_issues.py
@@ -518,3 +518,35 @@ class TestGitHubIssues(base.PyMySQLTestCase):
             self.assertEqual(cur.fetchone()[0], 246)
         finally:
             cur.execute("DROP PROCEDURE IF EXISTS `foo.bar`")
+
+class TestCallProcEdgeCases(base.PyMySQLTestCase):
+    def test_callproc_with_multi_resultset_and_out_params(self):
+        conn = self.connections[0]
+        with conn.cursor() as cursor:
+            cursor.execute("DROP PROCEDURE IF EXISTS test_multi_rs_proc;")
+            cursor.execute("""
+                CREATE PROCEDURE test_multi_rs_proc(IN p_in INT, OUT p_out INT)
+                BEGIN
+                    SELECT p_in AS internal_val;
+                    SET p_out = p_in * 2;
+                END;
+            """)
+
+            try:
+                cursor.callproc("test_multi_rs_proc", (5, 0))
+
+                # Read internal result set
+                res1 = cursor.fetchall()
+                self.assertEqual(res1[0][0], 5)
+
+                # Advance past internal result set and validate state
+                self.assertTrue(cursor.nextset())
+                self.assertIsNone(cursor.nextset())
+
+                # Fetch OUT parameter from server variable
+                cursor.execute("SELECT @_test_multi_rs_proc_1;")
+                out_val = cursor.fetchone()
+                self.assertEqual(out_val[0], 10)
+            finally:
+                cursor.execute("DROP PROCEDURE IF EXISTS test_multi_rs_proc;")
+                


### PR DESCRIPTION
## Summary

Adds a dedicated test case to verify `cursor.callproc()` behavior when executing stored procedures that return internal result sets alongside `OUT` parameters.

## Details

When a MySQL stored procedure contains internal queries (e.g., `SELECT` statements) and updates `OUT` parameters, the server returns multiple result set packets over the socket. 

This test ensures that:
1. Internal `SELECT` result sets remain accessible via `cursor.fetchall()`.
2. Draining result sets using `cursor.nextset()` allows session variables (`@_procname_n`) to be fetched reliably via subsequent `SELECT` queries without socket desynchronization.

## Testing

- Added `test_callproc_with_multi_resultset_and_out_params` under `pymysql/tests/test_issues.py`.
- Verified passing status locally against MySQL 8.0 / Cloud SQL proxy.
- Ran full integration test suite (`pytest pymysql/tests/`) to ensure zero regressions across standard `callproc` usage.